### PR TITLE
Refine Model Traits

### DIFF
--- a/app/src/BoundedContext/Canvas.elm
+++ b/app/src/BoundedContext/Canvas.elm
@@ -11,19 +11,18 @@ import BoundedContext.StrategicClassification as StrategicClassification exposin
 import BoundedContext.Message as Message exposing (Messages)
 import BoundedContext.UbiquitousLanguage as UbiquitousLanguage exposing (UbiquitousLanguage)
 import BoundedContext.BusinessDecision exposing (BusinessDecision)
+import BoundedContext.DomainRoles exposing (DomainRole)
 
 -- MODEL
 
 type alias BusinessDecisions = String
-
-type alias ModelTraits = String
 
 type alias BoundedContextCanvas =
   { description : String
   , classification : StrategicClassification
   , businessDecisions : List BusinessDecision
   , ubiquitousLanguage : UbiquitousLanguage
-  , modelTraits : ModelTraits
+  , domainRoles : List DomainRole
   , messages : Messages
   , dependencies : Dependencies
   }
@@ -46,7 +45,7 @@ init context =
   , classification = StrategicClassification.noClassification
   , businessDecisions = []
   , ubiquitousLanguage = UbiquitousLanguage.noLanguageTerms
-  , modelTraits = ""
+  , domainRoles = []
   , messages = Message.noMessages
   , dependencies = initDependencies
   }
@@ -73,7 +72,7 @@ modelEncoder context canvas =
     , ("classification", StrategicClassification.encoder canvas.classification)
     , ("businessDecisions", BoundedContext.BusinessDecision.modelsEncoder canvas.businessDecisions)
     , ("ubiquitousLanguage", UbiquitousLanguage.modelEncoder canvas.ubiquitousLanguage)
-    , ("modelTraits", Encode.string canvas.modelTraits)
+    , ("domainRoles", BoundedContext.DomainRoles.modelsEncoder canvas.domainRoles)
     , ("messages", Message.messagesEncoder canvas.messages)
     , ("dependencies", dependenciesEncoder canvas.dependencies)
     ]
@@ -100,6 +99,6 @@ modelDecoder =
     |> JP.optional "classification" StrategicClassification.decoder StrategicClassification.noClassification
     |> JP.optional "businessDecisions" BoundedContext.BusinessDecision.modelsDecoder []
     |> JP.optional "ubiquitousLanguage" UbiquitousLanguage.modelDecoder UbiquitousLanguage.noLanguageTerms
-    |> JP.optional "modelTraits" Decode.string ""
+    |> JP.optional "domainRoles" BoundedContext.DomainRoles.modelsDecoder []
     |> JP.optional "messages" Message.messagesDecoder Message.noMessages
     |> JP.optional "dependencies" dependenciesDecoder initDependencies

--- a/app/src/BoundedContext/DomainRoles.elm
+++ b/app/src/BoundedContext/DomainRoles.elm
@@ -1,0 +1,89 @@
+module BoundedContext.DomainRoles exposing (..)
+
+import Json.Encode as Encode
+import Json.Decode as Decode
+
+type DomainRole = 
+    DomainRole DomainRoleInternal
+
+type alias DomainRoles = List DomainRole
+
+type alias DomainRoleInternal = 
+    { name : String
+    , description : Maybe String
+    }
+
+type Problem
+  = DefinitionEmpty
+  | AlreadyExists
+
+getId : DomainRole -> String
+getId (DomainRole role) = 
+    String.toLower role.name
+
+getName : DomainRole -> String 
+getName (DomainRole role) =
+    role.name
+
+getDescription: DomainRole -> Maybe String
+getDescription (DomainRole role) =
+    role.description
+
+isUnique : String -> DomainRoles -> Bool
+isUnique name roles =
+  roles
+  |> List.map getId
+  |> List.member (name |> String.toLower)
+  |> not
+
+createDomainRole : DomainRoles -> String -> String -> Result Problem DomainRole
+createDomainRole existingRoles name description =
+    if String.isEmpty name then
+        Err DefinitionEmpty
+    else
+        if isUnique name existingRoles then
+            DomainRoleInternal name (if String.isEmpty description then Nothing else Just description)
+            |> DomainRole
+            |> Ok
+        else Err AlreadyExists
+
+insertDomainRole : DomainRoles -> DomainRole -> Result Problem DomainRoles
+insertDomainRole existingRoles role =
+    if existingRoles |> isUnique (getId role) then
+        List.singleton role
+        |> List.append existingRoles
+        |> Ok
+    else 
+        Err AlreadyExists
+
+removeDomainRole : DomainRoles -> String -> DomainRoles
+removeDomainRole existingRoles id =
+    List.filter (\item -> getId item /= id) existingRoles
+
+modelEncoder : DomainRole -> Encode.Value
+modelEncoder (DomainRole role) = 
+    Encode.object
+    [
+        ("name", Encode.string role.name),
+        ("description", 
+            case role.description of
+                Just v -> Encode.string v
+                Nothing -> Encode.null
+        )
+    ]
+
+modelsEncoder : DomainRoles -> Encode.Value
+modelsEncoder items = 
+    Encode.list modelEncoder items
+
+modelDecoder : Decode.Decoder DomainRole
+modelDecoder = 
+    Decode.map DomainRole
+        (Decode.map2 DomainRoleInternal
+            (Decode.field "name" Decode.string)
+            (Decode.maybe (Decode.field "description" Decode.string))
+        )
+
+modelsDecoder : Decode.Decoder DomainRoles
+modelsDecoder =
+    Decode.list modelDecoder

--- a/app/src/Page/Bcc/Edit/DomainRoles.elm
+++ b/app/src/Page/Bcc/Edit/DomainRoles.elm
@@ -1,0 +1,252 @@
+module Page.Bcc.Edit.DomainRoles exposing (..)
+
+import BoundedContext.DomainRoles exposing (..)
+
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick, onSubmit)
+
+import Bootstrap.Button as Button
+import Bootstrap.Card as Card
+import Bootstrap.Card.Block as Block
+import Bootstrap.Text as Text   
+import Bootstrap.Form as Form
+import Bootstrap.Form.Input as Input
+import Bootstrap.Form.Textarea as Textarea
+import Bootstrap.Form.Select as Select
+import Array
+
+type Msg
+    = Default 
+    | ShowCreateNew
+    | ShowChooseFrom
+    | CreateNew DomainRole
+    | ChangeName String
+    | ChangeDescription String
+    | CancelCreating
+    | Delete String 
+    | SelectRole String String
+
+type ChangingModel
+  = AddingNewDomainRole String String (Result BoundedContext.DomainRoles.Problem DomainRole)
+  | SelectingDomainRole String String (Result BoundedContext.DomainRoles.Problem DomainRole)
+
+type alias Model =
+  { roles : DomainRoles
+  , changingModel : Maybe ChangingModel
+  }
+
+init : DomainRoles -> Model
+init roles =
+  { roles = roles
+  , changingModel = Nothing
+  }
+
+update : Msg -> Model -> Model
+update msg model =
+    case (msg, model.changingModel) of
+        (ShowCreateNew, _) ->
+            { model | changingModel = Just <| AddingNewDomainRole "" "" (createDomainRole model.roles "" "") }
+
+        (ChangeName name, Just (AddingNewDomainRole _ description _)) ->
+            { model | changingModel = Just <| AddingNewDomainRole name description (createDomainRole model.roles name description) }
+
+        (ChangeDescription description, Just (AddingNewDomainRole name _ _)) ->
+            { model | changingModel = Just <| AddingNewDomainRole name description (createDomainRole model.roles name description) }
+
+        (SelectRole name description, Just (SelectingDomainRole _ _ _)) ->
+            { model | changingModel = Just <| SelectingDomainRole name description (createDomainRole model.roles name description)}
+
+        (CancelCreating, _) ->
+            { model | changingModel = Nothing}
+
+        (CreateNew role, Just (AddingNewDomainRole _ _ _)) ->
+            let
+                newRole = insertDomainRole model.roles role
+
+            in
+                case newRole of
+                    Ok roles ->
+                        { model
+                        | roles = roles
+                        , changingModel = Nothing
+                        }
+                    Err _ -> 
+                        model
+
+        (CreateNew role, Just (SelectingDomainRole _ _ _)) ->
+            let
+                newRole = insertDomainRole model.roles role
+
+            in
+                case newRole of
+                    Ok roles ->
+                        { model
+                        | roles = roles
+                        , changingModel = Nothing
+                        }
+                    Err _ -> 
+                        model
+
+        (Delete name, Nothing) ->
+            { model | roles = removeDomainRole model.roles name }
+
+        (ShowChooseFrom, _) ->
+            { model | changingModel = Just <| SelectingDomainRole "" "" (createDomainRole model.roles "" "") }
+        
+        _ -> model
+
+view : Model -> Html Msg
+view model =
+    Html.div []
+    [   viewCreateRole model.changingModel |> Card.view
+    ,   Html.dl []
+        (
+            List.map viewRole model.roles |> List.concat
+        )
+    ]
+
+viewRole : DomainRole -> List (Html Msg)
+viewRole role =
+  [ Html.dt []
+    [ text (getName role)
+    , Button.button
+      [ Button.secondary
+      , Button.small
+      , Button.onClick (Delete (role |> getId))
+      , Button.attrs [class "float-right"]
+      ]
+      [ text "X" ]
+    ]
+  , Html.dd
+    []
+    [ getDescription role
+      |> Maybe.map text
+      |> Maybe.withDefault (Html.i [] [ text "No description :-(" ])
+    ]
+  ]
+
+viewCreateRole : Maybe ChangingModel -> Card.Config Msg
+viewCreateRole model =
+    case model of
+        Just (SelectingDomainRole name description result) ->
+            let
+                (nameIsValid, anEvent, feedbackText) =
+                    case result of
+                        Ok d ->
+                            (True, [ onSubmit (CreateNew d) ], "")
+                        Err p ->
+                            let
+                                errorText =
+                                    case p of
+                                        DefinitionEmpty -> "No domain role name is specified"
+                                        AlreadyExists -> "The domain role with name '" ++ name ++ "' has already been defined before. Please use a distinct, case insensitive name."
+                            in
+                            (False, [], errorText)
+            in
+                Card.config [ Card.attrs [ class "mb-3", class "shadow" ] ]
+                |> Card.block []
+                [ Block.custom <|
+                    Form.form anEvent [
+                        Form.group []
+                        [ Form.label [ for "role_select" ] [ text "Select role from the list:" ]
+                        , viewSelectDomainRole
+                        , Button.button [ Button.outlineSecondary, Button.onClick CancelCreating, Button.attrs [ class "mr-2"] ] [ text "Cancel"]
+                        , Button.submitButton [ Button.primary, Button.disabled (not nameIsValid) ] [ text "Add this domain role" ]
+                        ]
+                    ]
+                ]
+    
+        Just (AddingNewDomainRole name description result) ->
+            let
+                (nameIsValid, anEvent, feedbackText) =
+                    case result of
+                        Ok d ->
+                            (True, [ onSubmit (CreateNew d) ], "")
+                        Err p ->
+                            let
+                                errorText =
+                                    case p of
+                                        DefinitionEmpty -> "No domain role name is specified"
+                                        AlreadyExists -> "The domain role with name '" ++ name ++ "' has already been defined before. Please use a distinct, case insensitive name."
+                            in
+                            (False, [], errorText)
+            in
+                Card.config [ Card.attrs [ class "mb-3", class "shadow" ] ]
+                |> Card.block []
+                [ Block.custom <|
+                    Form.form anEvent
+                    [ Form.group []
+                    [ Form.label [ for "name" ] [ text "Domain role name" ]
+                    , Input.text
+                        [ Input.id "name"
+                        , Input.value name
+                        , Input.onInput ChangeName
+                        , if nameIsValid
+                            then Input.success
+                            else Input.danger
+                        ]
+                    , Form.help [] [ text "The domain role name that is used inside this bounded context." ]
+                    , Form.invalidFeedback [] [ text feedbackText]
+                    ]
+                    , Form.group []
+                    [ Form.label [ for "description" ] [ text "Description" ]
+                    , Textarea.textarea
+                        [ Textarea.id "description"
+                        , Textarea.value description
+                        , Textarea.onInput ChangeDescription
+                        ]
+                    , Form.help [] [ text "Define the meaning of the this domain role inside this bounded context." ]
+                    ]
+                    , Button.button [ Button.outlineSecondary, Button.onClick CancelCreating, Button.attrs [ class "mr-2"] ] [ text "Cancel"]
+                    , Button.submitButton [ Button.primary, Button.disabled (not nameIsValid) ] [ text "Add new domain role" ]
+                    ]
+                ]
+        _ ->
+            Card.config [ Card.attrs [ class "mb-3", class "shadow" ], Card.align Text.alignXsCenter ]
+                |> Card.block []
+            [ Block.custom <| 
+                Button.button [ Button.primary, Button.onClick ShowCreateNew ] [ text "Add new domain role" ]
+            , Block.custom <| 
+                div [] [ text "" ]
+            , Block.custom <| 
+                Button.button [ Button.primary, Button.onClick ShowChooseFrom ] [ text "Choose from pre-defined list" ]
+            ]
+
+viewSelectDomainRole : Html Msg
+viewSelectDomainRole =
+  let
+    roles =
+      [ ("Specification Model", "Produces a document describing a job/request that needs to be performed. Example: Advertising Campaign Builder")
+      , ("Execution Model", "Performs or tracks a job. Example: Advertising Campaign Engine")
+      , ("Audit Model", "Monitors the execution. Example: Advertising Campaign Analyser")
+      , ("Approver", "Receives requests and determines if they should progress to the next step of the process. Example: Fraud Check")
+      , ("Enforcer", "Ensures that other contexts carry out certain operations. Example: GDPR Context (ensures other contexts delete all of a user’s data)")
+      , ("Octopus Enforcer", "Ensures that multiple/all contexts in the system all comply with a standard rule. Example: GDPR Context (as above)")
+      , ("Interchanger", "Translates between multiple ubiquitous languages.")
+      , ("Gateway", "Sits at the edge of a system and manages inbound and/or outbound communication. Example: IoT Message Gateway")
+      , ("Gateway Interchange", "The combination of a gateway and an interchange.")
+      , ("Dogfood Context", "Simulates the customer experience of using the core bounded contexts. Example: Whitelabel music store")
+      , ("Bubble Context", "Sits in-front of legacy contexts providing a new, cleaner model while legacy contexts are being replaced.")
+      , ("Autonomous Bubble", "Bubble context which has its own data store and synchronises data asynchronously with the legacy contexts.")
+      , ("Brain Context (likely anti-pattern)", "Contains a large number of important rules and many other contexts depend on it. Example: rules engine containing all the domain rules")
+      , ("Funnel Context", "Receives documents from multiple upstream contexts and passes them to a single downstream context in a standard format (after applying its own rules).")
+      , ("Engagement Context", "Provides key features which attract users to keep using the product. Example: Free Financial Advice Context")
+      ]
+  in
+    Form.group []
+      [ Select.select [ Select.id "role_select", Select.onChange (\name -> SelectRole name (getRoleDescriptionWithName name roles)) ]
+          (List.map (\(name, description) -> Select.item [ value name ] [ text (name ++ " (" ++ description ++ ")")]) roles)
+      ]
+
+getRoleDescriptionWithName : String -> List (String, String) -> String
+getRoleDescriptionWithName lookupName list = 
+    List.filter (\(name, desc) -> lookupName == name) list 
+    |>
+    Array.fromList
+    |> 
+    Array.get 0
+    |>
+    Maybe.withDefault ("", "")
+    |>
+    Tuple.second

--- a/app/src/Page/Bcc/Edit/DomainRoles.elm
+++ b/app/src/Page/Bcc/Edit/DomainRoles.elm
@@ -208,7 +208,7 @@ viewCreateRole model =
             [ Block.custom <| 
                 Button.button [ Button.primary, Button.onClick ShowCreateNew ] [ text "Add new domain role" ]
             , Block.custom <| 
-                div [] [ text "" ]
+                div [] [ Html.br [] [] ]
             , Block.custom <| 
                 Button.button [ Button.primary, Button.onClick ShowChooseFrom ] [ text "Choose from pre-defined list" ]
             ]


### PR DESCRIPTION
This MR refines Model Traits as the following:

- Rename Model Traits to Domain Roles
- Replace plain string with a (name, description) pair
- Add an option to create a new domain role by manually entering details
- Add an option to select a domain role from the pre-defined list

Addressing https://github.com/Softwarepark/Contexture/issues/39