### PR TITLE
using latest version of setup-elm

### DIFF
--- a/.github/workflows/CI-frontend.yml
+++ b/.github/workflows/CI-frontend.yml
@@ -23,6 +23,6 @@ jobs:
 
 
     - name: Setup Elm
-      uses: justgook/setup-elm@v1
+      uses: justgook/setup-elm
     - run: elm make src/Main.elm
       working-directory: ./app

--- a/.github/workflows/deploy-azure.yml
+++ b/.github/workflows/deploy-azure.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Setup Elm
-      uses: justgook/setup-elm@v1
+      uses: justgook/setup-elm
     - run: elm make src/Main.elm --output=../server/public/index.html
       working-directory: ./app
     - name: Use Node.js ${{ env.NODE_VERSION }}


### PR DESCRIPTION
CI is currently failing with

> Error: Unable to process command '::add-path::/home/runner/elm_home/' successfully.
14
Error: The `add-path` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/