### PR TITLE
Search api

### DIFF
--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -217,7 +217,7 @@ module BoundedContextSearch =
             let contextId = Guid.NewGuid()
             let domainId = Guid.NewGuid()
 
-            let added =
+            let namespaceAdded =
                 NamespaceAdded
                     { Fixtures.namespaceDefinition contextId namespaceId with
                           Labels =
@@ -233,7 +233,7 @@ module BoundedContextSearch =
                 Given.noEvents
                 |> Given.andOneEvent (Fixtures.domainCreated domainId)
                 |> Given.andOneEvent (Fixtures.boundedContextCreated domainId contextId)
-                |> Given.andOneEvent added
+                |> Given.andOneEvent namespaceAdded
 
             use testEnvironment = Prepare.withGiven clock given
 
@@ -270,14 +270,14 @@ module BoundedContextSearch =
             use testEnvironment = Prepare.withGiven clock given
 
             //act - search by name
-            let! result = testEnvironment |> When.searchingFor $"name=lab"
+            let! result = testEnvironment |> When.searchingFor $"Label.name=lab"
 
             // assert
             Then.NotEmpty result
             Then.Collection(result, (fun x -> Then.Equal(contextId, x)))
 
             //act - search by value
-            let! result = testEnvironment |> When.searchingFor "value=val"
+            let! result = testEnvironment |> When.searchingFor "Label.value=val"
 
             // assert
             Then.NotEmpty result
@@ -297,14 +297,14 @@ module BoundedContextSearch =
             let domainId = Guid.NewGuid()
             let name = "myname"
 
-            let added =
+            let namespaceAdded =
                 NamespaceAdded
                     { Fixtures.namespaceDefinition contextId namespaceId with
                         Name = name
                         NamespaceTemplateId = Some templateId }
                 |> Utils.asEvent contextId
 
-            let addedOther =
+            let otherNamespaceAdded =
                 NamespaceAdded
                     { Fixtures.namespaceDefinition otherContextId (Guid.NewGuid()) with
                           Name = "the other namespace"
@@ -316,15 +316,15 @@ module BoundedContextSearch =
                 |> Given.andOneEvent (Fixtures.domainCreated domainId)
                 |> Given.andOneEvent (Fixtures.boundedContextCreated domainId otherContextId)
                 |> Given.andOneEvent (Fixtures.boundedContextCreated domainId contextId)
-                |> Given.andOneEvent added
-                |> Given.andOneEvent addedOther
+                |> Given.andOneEvent namespaceAdded
+                |> Given.andOneEvent otherNamespaceAdded
 
             use testEnvironment = Prepare.withGiven clock given
 
             //act - search by name
             let! result =
                 testEnvironment
-                |> When.searchingFor $"name=lab&NamespaceTemplate=%O{templateId}"
+                |> When.searchingFor $"Label.name=lab&Namespace.Template=%O{templateId}"
 
             // assert
             Then.NotEmpty result
@@ -333,7 +333,7 @@ module BoundedContextSearch =
             //act - search by value
             let! result =
                 testEnvironment
-                |> When.searchingFor $"value=val&NamespaceTemplate=%O{templateId}"
+                |> When.searchingFor $"Label.value=val&Namespace.Template=%O{templateId}"
 
             // assert
             Then.NotEmpty result
@@ -342,7 +342,7 @@ module BoundedContextSearch =
             // act - search by namespace name
             let! result =
                 testEnvironment
-                |> When.searchingFor $"value=val&Namespace=%s{name}"
+                |> When.searchingFor $"Label.value=val&Namespace.Name=%s{name}"
 
             // assert
             Then.NotEmpty result

--- a/backend/Contexture.Api/BoundedContexts.fs
+++ b/backend/Contexture.Api/BoundedContexts.fs
@@ -131,11 +131,11 @@ module BoundedContexts =
                         |> Option.map(ReadModels.Namespace.FindNamespace.byNamespaceName database)
 
                     let namespacesByLabel =
-                        database |> ReadModels.Namespace.FindNamespace.namespacesByLabel
+                        database |> ReadModels.Namespace.FindNamespace.byLabel
 
                     let namespaces =
                         namespacesByLabel
-                        |> ReadModels.Namespace.findByLabelName item.Name
+                        |> ReadModels.Namespace.FindNamespace.ByLabel.findByLabelName item.Name
                         |> Set.filter
                             (fun { NamespaceTemplateId = template } ->
                                 match item.NamespaceTemplate with
@@ -156,7 +156,7 @@ module BoundedContexts =
                         |> Set.map (fun m -> m.NamespaceId)
 
                     let boundedContextsByNamespace =
-                        ReadModels.Namespace.boundedContextByNamespace database
+                        ReadModels.Namespace.FindBoundedContexts.byNamespace database
 
                     let boundedContextIds =
                         namespaces
@@ -176,13 +176,13 @@ module BoundedContexts =
 
                     let namespaces =
                         database
-                        |> ReadModels.Namespace.FindNamespace.namespacesByLabel
-                        |> ReadModels.Namespace.getByLabelName name
+                        |> ReadModels.Namespace.FindNamespace.byLabel
+                        |> ReadModels.Namespace.FindNamespace.ByLabel.getByLabelName name
                         |> Set.filter (fun { Value = v } -> v = Some value)
                         |> Set.map (fun n -> n.NamespaceId)
 
                     let boundedContextsByNamespace =
-                        ReadModels.Namespace.boundedContextByNamespace database
+                        ReadModels.Namespace.FindBoundedContexts.byNamespace database
 
                     let boundedContextIds =
                         namespaces

--- a/backend/Contexture.Api/Domains.fs
+++ b/backend/Contexture.Api/Domains.fs
@@ -190,7 +190,7 @@ module Domains =
             fun (next: HttpFunc) (ctx: HttpContext) ->
                 let database = ctx.GetService<EventStore>()
                 let boundedContexts = BoundedContext.allBoundedContexts database
-                let boundedContextsOf = BoundedContext.boundedContextLookup boundedContexts
+                let boundedContextsOf = BoundedContext.boundedContextsByDomainLookup boundedContexts
                 let namespacesOf = Namespace.allNamespacesByContext database
 
                 let boundedContexts =

--- a/backend/Contexture.Api/Infrastructure.fs
+++ b/backend/Contexture.Api/Infrastructure.fs
@@ -1,5 +1,6 @@
 namespace Contexture.Api.Infrastructure
 
+open System
 open System.Collections.Concurrent
 open System.Collections.Generic
 
@@ -14,39 +15,52 @@ type EventEnvelope<'Event> =
     { Metadata: EventMetadata
       Event: 'Event }
 
+type EventEnvelope =
+    { Metadata: EventMetadata
+      Payload: obj
+      EventType: Type }
+
 type Subscription<'E> = EventEnvelope<'E> list -> unit
 
-type EventStore(items: Dictionary<EventSource * System.Type, EventEnvelope<obj> list>,
-                subscriptions: ConcurrentDictionary<System.Type, Subscription<obj> list>) =
+type private SubscriptionWrapper = EventEnvelope list -> unit
 
+module EventEnvelope =
+    let box (envelope: EventEnvelope<'E>) =
+        { Metadata = envelope.Metadata
+          Payload = box envelope.Event
+          EventType = typeof<'E> }
+        
+    let unbox (envelope: EventEnvelope): EventEnvelope<'E> =
+        { Metadata = envelope.Metadata
+          Event = unbox<'E> envelope.Payload }
+
+type EventStore private(items: Dictionary<EventSource * System.Type, EventEnvelope list>,
+                subscriptions: ConcurrentDictionary<System.Type, SubscriptionWrapper list>) =
     let byEventType =
         items.Values
-        |> Seq.choose (fun v ->
-            v
-            |> List.tryHead
-            |> Option.map (fun first -> first.Event.GetType(), v))
+        |> Seq.collect id
+        |> Seq.toList
+        |> List.groupBy (fun v -> v.EventType)
         |> dict
         |> Dictionary
 
-    let boxEnvelope (envelope: EventEnvelope<'E>) =
-        { Metadata = envelope.Metadata
-          Event = box envelope.Event }
-
-    let unboxEnvelope (envelope: EventEnvelope<obj>): EventEnvelope<'E> =
-        { Metadata = envelope.Metadata
-          Event = unbox<'E> envelope.Event }
-
     let stream source =
         let (success, events) = items.TryGetValue source
-        if success then events |> List.map unboxEnvelope else []
+        if success then events else []
 
     let subscriptionsOf key =
         let (success, items) = subscriptions.TryGetValue key
         if success then items else []
 
-    let getAll key: EventEnvelope<'E> list =
+    let getAll key: EventEnvelope list =
         let (success, items) = byEventType.TryGetValue key
-        if success then items |> List.map unboxEnvelope else []
+        if success then items else []
+        
+    let asTyped items : EventEnvelope<'E> list =
+        items |> List.map EventEnvelope.unbox
+        
+    let asUntyped items =
+        items |> List.map EventEnvelope.box
 
     let append (newItems: EventEnvelope<'E> list) =
         newItems
@@ -57,17 +71,18 @@ type EventStore(items: Dictionary<EventSource * System.Type, EventEnvelope<obj> 
             let fullStream =
                 key
                 |> stream
+                |> asTyped
                 |> fun s -> s @ [ envelope ]
-                |> List.map boxEnvelope
+                |> asUntyped
 
             items.[key] <- fullStream
             let allEvents = getAll eventType
-            byEventType.[eventType] <- allEvents @ [ boxEnvelope envelope ])
+            byEventType.[eventType] <- allEvents @ [ EventEnvelope.box envelope ])
 
         subscriptionsOf typedefof<'E>
         |> List.iter (fun subscription ->
             let upcastSubscription events =
-                events |> List.map boxEnvelope |> subscription
+                events |> asUntyped |> subscription
 
             upcastSubscription newItems)
 
@@ -75,19 +90,27 @@ type EventStore(items: Dictionary<EventSource * System.Type, EventEnvelope<obj> 
         let key = typedefof<'E>
 
         let upcastSubscription events =
-            events |> List.map unboxEnvelope |> subscription
+            events |> asTyped |> subscription
 
         subscriptions.AddOrUpdate
             (key, (fun _ -> [ upcastSubscription ]), (fun _ subscriptions -> subscriptions @ [ upcastSubscription ]))
         |> ignore
 
-    let get (): EventEnvelope<'E> list = getAll typedefof<'E>
-
+    let get (): EventEnvelope<'E> list = typeof<'E> |> getAll |> asTyped
 
     static member Empty =
         EventStore(Dictionary(), ConcurrentDictionary())
+        
+    static member With(items: EventEnvelope list) =
+        EventStore(
+            items
+            |> List.groupBy(fun i -> (i.Metadata.Source,i.EventType))
+            |> dict
+            |> Dictionary,
+            ConcurrentDictionary()
+            )
 
-    member __.Stream name: EventEnvelope<'E> list = stream (name,typedefof<'E>)
+    member __.Stream name: EventEnvelope<'E> list = stream (name,typeof<'E>) |> asTyped
     member __.Append items = lock __ (fun () -> append items)
     member __.Subscribe(subscription: Subscription<'E>) = subscribe subscription
     member __.Get() = get ()
@@ -98,7 +121,7 @@ module Projections =
           Update: 'State -> 'Event -> 'State }
 
     let projectIntoMap projection =
-        fun state eventEnvelope ->
+        fun state (eventEnvelope:EventEnvelope<_>) ->
             state
             |> Map.tryFind eventEnvelope.Metadata.Source
             |> Option.defaultValue projection.Init
@@ -109,7 +132,7 @@ module Projections =
                 state
                 |> Map.add eventEnvelope.Metadata.Source newState
 
-    let project projection events =
+    let project projection (events:EventEnvelope<_> list) =
         events
         |> List.map (fun e -> e.Event)
         |> List.fold projection.Update projection.Init

--- a/backend/Contexture.Api/Search.fs
+++ b/backend/Contexture.Api/Search.fs
@@ -4,6 +4,7 @@ open System
 open Contexture.Api
 open Contexture.Api.Aggregates
 open Contexture.Api.BoundedContexts
+open Contexture.Api.Entities
 open Contexture.Api.ReadModels
 open Contexture.Api.Domains
 open Contexture.Api.Infrastructure
@@ -17,6 +18,7 @@ open Microsoft.Extensions.Hosting
 
 
 module Search =
+    
 
     module Views =
         

--- a/backend/Contexture.Api/Search.fs
+++ b/backend/Contexture.Api/Search.fs
@@ -18,7 +18,6 @@ open Microsoft.Extensions.Hosting
 
 
 module Search =
-    
 
     module Views =
         


### PR DESCRIPTION
Reworked search functionality
- based on `/api/boundedContexts` now
- uses the following query parameters (combined with AND) to find bounded contexts and returns them:
  - `Namespace.Name` to search for a namespace name
  - `Namespace.Template` to search for namespace based on the given template id
  - `Label.Name`
  - `Label.Value`