### PR TITLE
Search operators and support for Bounded Contexts & Domains

### DIFF
--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -131,6 +131,7 @@ module BoundedContexts =
     [<InlineData("Namespace.name", "Team")>]
     [<InlineData("Namespace.template", "A9F5D70E-B947-40B6-B7BE-4AC45CFE7F34")>]
     [<InlineData("Domain.name", "domain")>]
+    [<InlineData("Domain.key", "DO-1")>]
     let ``Can find the bounded context when searching with a single, exact parameter``
         (
             parameterName: string,

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -20,8 +20,8 @@ module Namespaces =
         task {
             // arrange
             let environment = FixedTimeEnvironment.FromSystemClock()
-            let domainId = environment |> Identifiers.guid
-            let contextId = environment |> Identifiers.guid
+            let domainId = environment |> PseudoRandom.guid
+            let contextId = environment |> PseudoRandom.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
@@ -83,8 +83,8 @@ module BoundedContexts =
             let environment = FixedTimeEnvironment.FromSystemClock()
 
             // arrange
-            let contextId = environment |> Identifiers.guid
-            let domainId = environment |> Identifiers.guid
+            let contextId = environment |> PseudoRandom.guid
+            let domainId = environment |> PseudoRandom.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
@@ -107,8 +107,8 @@ module BoundedContexts =
             let environment = FixedTimeEnvironment.FromSystemClock()
 
             // arrange
-            let contextId = environment |> Identifiers.guid
-            let domainId = environment |> Identifiers.guid
+            let contextId = environment |> PseudoRandom.guid
+            let domainId = environment |> PseudoRandom.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
@@ -141,9 +141,9 @@ module BoundedContexts =
             let namespaceTemplateId =
                 Guid("A9F5D70E-B947-40B6-B7BE-4AC45CFE7F34")
 
-            let namespaceId = simulation |> Identifiers.guid
-            let contextId = simulation |> Identifiers.guid
-            let domainId = simulation |> Identifiers.guid
+            let namespaceId = simulation |> PseudoRandom.guid
+            let contextId = simulation |> PseudoRandom.guid
+            let domainId = simulation |> PseudoRandom.guid
 
             let searchedBoundedContext =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
@@ -201,9 +201,9 @@ module BoundedContexts =
         type ``with a single string based parameter``() =
             let simulation = FixedTimeEnvironment.FromSystemClock()
 
-            let namespaceId = simulation |> Identifiers.guid
-            let contextId = simulation |> Identifiers.guid
-            let domainId = simulation |> Identifiers.guid
+            let namespaceId = simulation |> PseudoRandom.guid
+            let contextId = simulation |> PseudoRandom.guid
+            let domainId = simulation |> PseudoRandom.guid
 
             [<Fact>]
             member __.``it is possible to find label names by using 'arch*' as StartsWith``() =

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -292,54 +292,6 @@ module BoundedContexts =
             Then.Contains(contextId, result |> Array.map (fun i -> i.Id))
         }
 
-    [<Fact>]
-    let ``Can list bounded contexts by label and value`` () =
-        task {
-            let clock = FixedTimeEnvironment.FromSystemClock()
-
-            // arrange
-            let namespaceId = Guid.NewGuid()
-            let contextId = Guid.NewGuid()
-            let domainId = Guid.NewGuid()
-
-            let namespaceAdded =
-                NamespaceAdded
-                    { Fixtures.namespaceDefinition contextId namespaceId with
-                          Labels =
-                              [ { Fixtures.newLabel () with
-                                      Name = "l1"
-                                      Value = Some "v1" }
-                                { Fixtures.newLabel () with
-                                      Name = "l2"
-                                      Value = Some "v2" } ] }
-                |> Utils.asEvent contextId
-
-            let given =
-                Given.noEvents
-                |> Given.andOneEvent (
-                    domainId
-                    |> Fixtures.domainDefinition
-                    |> Fixtures.domainCreated
-                )
-                |> Given.andOneEvent (
-                    contextId
-                    |> Fixtures.boundedContextDefinition domainId
-                    |> Fixtures.boundedContextCreated
-                )
-                |> Given.andOneEvent namespaceAdded
-
-            use testEnvironment = Prepare.withGiven clock given
-
-            //act
-            let! result =
-                testEnvironment
-                |> When.gettingJson<{| Id: BoundedContextId |} array> (sprintf "api/boundedContexts/%s/%s" "l1" "v1")
-
-            // assert
-            Then.NotEmpty result
-            Then.Contains(contextId, result |> Array.map (fun i -> i.Id))
-        }
-
     [<Theory>]
     [<InlineData("Label.name", "label")>]
     [<InlineData("Label.value", "value")>]

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -270,43 +270,6 @@ module BoundedContexts =
         }
 
     [<Fact>]
-    let ``Can still list bounded contexts when attaching a query string`` () =
-        task {
-            let clock = FixedTimeEnvironment.FromSystemClock()
-
-            // arrange
-            let contextId = Guid.NewGuid()
-            let domainId = Guid.NewGuid()
-
-            let given =
-                Given.noEvents
-                |> Given.andOneEvent (
-                    domainId
-                    |> Fixtures.domainDefinition
-                    |> Fixtures.domainCreated
-                )
-                |> Given.andOneEvent (
-                    contextId
-                    |> Fixtures.boundedContextDefinition domainId
-                    |> Fixtures.boundedContextCreated
-                )
-
-
-            use testEnvironment = Prepare.withGiven clock given
-
-            //act
-            let! result =
-                testEnvironment
-                |> When.gettingJson<{| Id: BoundedContextId |} array> (
-                    sprintf "api/boundedContexts?bar.foo=like|baz&foo=bar,baz,blub&bar=*test*"
-                )
-
-            // assert
-            Then.NotEmpty result
-            Then.Contains(contextId, result |> Array.map (fun i -> i.Id))
-        }
-
-    [<Fact>]
     let ``Can list bounded contexts by label and value`` () =
         task {
             let clock = FixedTimeEnvironment.FromSystemClock()

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -132,6 +132,8 @@ module BoundedContexts =
     [<InlineData("Namespace.template", "A9F5D70E-B947-40B6-B7BE-4AC45CFE7F34")>]
     [<InlineData("Domain.name", "domain")>]
     [<InlineData("Domain.key", "DO-1")>]
+    [<InlineData("BoundedContext.name", "bounded-context")>]
+    [<InlineData("BoundedContext.key", "BC-1")>]
     let ``Can find the bounded context when searching with a single, exact parameter``
         (
             parameterName: string,

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -1,9 +1,7 @@
 module Contexture.Api.Tests.ApiTests
 
 open System
-open System.IO
-open System.Net.Http
-open System.Threading
+
 open Contexture.Api.Aggregates
 open Contexture.Api.Aggregates.BoundedContext
 open Contexture.Api.Aggregates.Domain
@@ -15,187 +13,20 @@ open FSharp.Control.Tasks
 open Xunit.Sdk
 open Contexture.Api.Tests.EnvironmentSimulation
 
-type Given = EventEnvelope list
-
-module Given =
-    let noEvents = []
-    let anEvent event = [ event ]
-    let andOneEvent event given = given @ [ event ]
-    let andEvents events given = given @ events
-
-module When =
-    open System.Net.Http.Json
-    open TestHost
-
-    let postingJson (url: string) (jsonContent: string) (environment: TestHostEnvironment) =
-        task {
-            let! result = environment.Client.PostAsync(url, new StringContent(jsonContent))
-            return result.EnsureSuccessStatusCode()
-        }
-
-    let gettingJson<'t> (url: string) (environment: TestHostEnvironment) =
-        task {
-            let! result = environment.Client.GetFromJsonAsync<'t>(url)
-            return result
-        }
-
-type Then = Assert
-
-module Utils =
-    let asEvent id event =
-        fun (environment: ISimulateEnvironment) ->
-            { Event = event
-              Metadata =
-                  { Source = id
-                    RecordedAt = environment.Time() } }
-            |> EventEnvelope.box
-
-    let singleEvent<'e> (eventStore: EventStore) : EventEnvelope<'e> =
-        let events = eventStore.Get<'e>()
-        Then.Single events
-
-module Fixtures =
-    module Domain =
-        [<Literal>]
-        let Name = "domain"
-
-        let definition domainId : DomainCreated =
-            { DomainId = domainId; Name = "domain" }
-
-        let domainCreated definition =
-            DomainCreated definition
-            |> Utils.asEvent definition.DomainId
-
-    module BoundedContext =
-        [<Literal>]
-        let Name = "bounded-context"
-
-        let definition domainId contextId =
-            { BoundedContextId = contextId
-              Name = Name
-              DomainId = domainId }
-
-        let boundedContextCreated definition =
-            BoundedContextCreated definition
-            |> Utils.asEvent definition.BoundedContextId
-
-    module Label =
-
-        [<Literal>]
-        let Name = "architect"
-
-        [<Literal>]
-        let Value = "John Doe"
-
-        let newLabel labelId =
-            { LabelId = labelId
-              Name = Name
-              Value = Some Value
-              Template = None }
-
-    module Namespace =
-
-        [<Literal>]
-        let Name = "Team"
-
-        let definition2 contextId namespaceId labelId =
-            { BoundedContextId = contextId
-              Name = Name
-              NamespaceId = namespaceId
-              NamespaceTemplateId = None
-              Labels = [ Label.newLabel labelId ] }
-
-        let definition contextId namespaceId =
-            { BoundedContextId = contextId
-              Name = Name
-              NamespaceId = namespaceId
-              NamespaceTemplateId = None
-              Labels = [] }
-
-        let appendLabel (label: LabelDefinition) (definition: NamespaceAdded) =
-            { definition with
-                  Labels = label :: definition.Labels }
-
-        let namespaceAdded definition =
-            NamespaceAdded definition
-            |> Utils.asEvent definition.BoundedContextId
-
-    module RandomDomainAndBoundedContextAndNamespace =
-        let given environment =
-            let namespaceId = environment |> Identifiers.guid
-            let contextId = environment |> Identifiers.guid
-            let domainId = environment |> Identifiers.guid
-
-            Given.noEvents
-            |> Given.andOneEvent (
-                { Domain.definition domainId with
-                      Name =
-                          environment
-                          |> Identifiers.nameWithGuid "random-domain-name" }
-                |> Domain.domainCreated
-            )
-            |> Given.andOneEvent (
-                { BoundedContext.definition domainId contextId with
-                      Name =
-                          environment
-                          |> Identifiers.nameWithGuid "random-context-name" }
-                |> BoundedContext.boundedContextCreated
-            )
-            |> Given.andOneEvent (
-                { Namespace.definition contextId namespaceId with
-                      Name =
-                          environment
-                          |> Identifiers.nameWithGuid "random-namespace-name"
-                      Labels =
-                          [ { LabelId = environment |> Identifiers.guid
-                              Name =
-                                  environment
-                                  |> Identifiers.nameWithGuid "random-label-name"
-                              Value =
-                                  environment
-                                  |> Identifiers.nameWithGuid "random-label-value"
-                                  |> Some
-                              Template = None } ] }
-                |> Namespace.namespaceAdded
-            )
-
-    module Builders =
-        let givenADomainWithOneBoundedContext domainId contextId =
-            Given.noEvents
-            |> Given.andOneEvent (
-                domainId
-                |> Domain.definition
-                |> Domain.domainCreated
-            )
-            |> Given.andOneEvent (
-                contextId
-                |> BoundedContext.definition domainId
-                |> BoundedContext.boundedContextCreated
-            )
-
-        let givenADomainWithOneBoundedContextAndOneNamespace domainId contextId namespaceId =
-            givenADomainWithOneBoundedContext domainId contextId
-            |> Given.andOneEvent (
-                namespaceId
-                |> Namespace.definition contextId
-                |> Namespace.appendLabel (Label.newLabel (Guid.NewGuid()))
-                |> Namespace.namespaceAdded
-            )
-
 module Namespaces =
 
     [<Fact>]
     let ``Can create a new namespace`` () =
         task {
             // arrange
-            let clock = FixedTimeEnvironment.FromSystemClock()
-            let domainId = Guid.NewGuid()
-            let contextId = Guid.NewGuid()
+            let environment = FixedTimeEnvironment.FromSystemClock()
+            let domainId = environment |> Identifiers.guid
+            let contextId = environment |> Identifiers.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
 
-            use testEnvironment = Prepare.withGiven clock given
+            use testEnvironment = Prepare.withGiven environment given
 
             //act
             let createNamespaceContent = "{
@@ -249,16 +80,16 @@ module BoundedContexts =
     [<Fact>]
     let ``Can list all bounded contexts`` () =
         task {
-            let clock = FixedTimeEnvironment.FromSystemClock()
+            let environment = FixedTimeEnvironment.FromSystemClock()
 
             // arrange
-            let contextId = Guid.NewGuid()
-            let domainId = Guid.NewGuid()
+            let contextId = environment |> Identifiers.guid
+            let domainId = environment |> Identifiers.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
 
-            use testEnvironment = Prepare.withGiven clock given
+            use testEnvironment = Prepare.withGiven environment given
 
             //act
             let! result =
@@ -273,16 +104,16 @@ module BoundedContexts =
     [<Fact>]
     let ``Can still list bounded contexts when attaching a random query string`` () =
         task {
-            let clock = FixedTimeEnvironment.FromSystemClock()
+            let environment = FixedTimeEnvironment.FromSystemClock()
 
             // arrange
-            let contextId = Guid.NewGuid()
-            let domainId = Guid.NewGuid()
+            let contextId = environment |> Identifiers.guid
+            let domainId = environment |> Identifiers.guid
 
             let given =
                 Fixtures.Builders.givenADomainWithOneBoundedContext domainId contextId
 
-            use testEnvironment = Prepare.withGiven clock given
+            use testEnvironment = Prepare.withGiven environment given
 
             //act
             let! result =
@@ -324,7 +155,7 @@ module BoundedContexts =
                 )
 
             let randomBoundedContext =
-                Fixtures.RandomDomainAndBoundedContextAndNamespace.given simulation
+                Fixtures.Builders.givenARandomDomainWithBoundedContextAndNamespace simulation
 
             let given =
                 searchedBoundedContext @ randomBoundedContext
@@ -358,11 +189,9 @@ module BoundedContexts =
                 Then.NotEmpty result
                 Then.Collection(result, (fun x -> Then.Equal(contextId, x)))
 
-
-
         let prepareTestEnvironment simulation searchedBoundedContext =
             let randomBoundedContext =
-                Fixtures.RandomDomainAndBoundedContextAndNamespace.given simulation
+                Fixtures.Builders.givenARandomDomainWithBoundedContextAndNamespace simulation
 
             let given =
                 searchedBoundedContext @ randomBoundedContext
@@ -442,7 +271,7 @@ module BoundedContexts =
     [<Fact>]
     let ``Can search for bounded contexts by label and value for a specific template`` () =
         task {
-            let clock = FixedTimeEnvironment.FromSystemClock()
+            let environment = FixedTimeEnvironment.FromSystemClock()
 
             // arrange
             let namespaceId = Guid.NewGuid()
@@ -478,7 +307,7 @@ module BoundedContexts =
                 |> Given.andOneEvent namespaceAdded
                 |> Given.andOneEvent otherNamespaceAdded
 
-            use testEnvironment = Prepare.withGiven clock given
+            use testEnvironment = Prepare.withGiven environment given
 
             //act - search by name
             let! result =

--- a/backend/Contexture.Api.Tests/ApiTests.fs
+++ b/backend/Contexture.Api.Tests/ApiTests.fs
@@ -130,6 +130,7 @@ module BoundedContexts =
     [<InlineData("Label.value", "John Doe")>]
     [<InlineData("Namespace.name", "Team")>]
     [<InlineData("Namespace.template", "A9F5D70E-B947-40B6-B7BE-4AC45CFE7F34")>]
+    [<InlineData("Domain.name", "domain")>]
     let ``Can find the bounded context when searching with a single, exact parameter``
         (
             parameterName: string,

--- a/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
+++ b/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <Compile Include="Tests.fs" />
+        <Compile Include="EnvironmentSimulation.fs" />
         <Compile Include="ApiTests.fs" />
     </ItemGroup>
 

--- a/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
+++ b/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
@@ -10,7 +10,8 @@
     <ItemGroup>
         <Compile Include="Tests.fs" />
         <Compile Include="EnvironmentSimulation.fs" />
-        <Compile Include="TestHost.fs" />
+        <Compile Include="TestUtils.fs" />
+        <Compile Include="Fixtures.fs" />
         <Compile Include="ApiTests.fs" />
     </ItemGroup>
 

--- a/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
+++ b/backend/Contexture.Api.Tests/Contexture.Api.Tests.fsproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <Compile Include="Tests.fs" />
         <Compile Include="EnvironmentSimulation.fs" />
+        <Compile Include="TestHost.fs" />
         <Compile Include="ApiTests.fs" />
     </ItemGroup>
 

--- a/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
+++ b/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
@@ -1,0 +1,40 @@
+namespace Contexture.Api.Tests.EnvironmentSimulation
+
+open System
+open System.Threading
+
+type Clock = unit -> System.DateTime
+
+module Clock =
+    
+    let systemClock =
+        fun () -> System.DateTime.UtcNow
+
+    let currentInstant (clock: Clock) = clock()
+    let dateTimeUtc (clock: Clock) =
+        clock
+        |> currentInstant
+        |> fun t -> t.ToUniversalTime()
+
+type ISimulateEnvironment =
+    abstract Time: unit -> System.DateTime
+    abstract NextId: unit -> int
+
+type FixedTimeEnvironment(now: DateTime, seed: int) =
+    let ids = ref seed
+
+    let nextId () =
+        Interlocked.Increment(ids)
+
+    static member FromInstance(now: DateTime) =
+        FixedTimeEnvironment(now, 0) :> ISimulateEnvironment
+
+    static member FromClock(clock: Clock) =
+        FixedTimeEnvironment.FromInstance(Clock.currentInstant clock)
+
+    static member FromSystemClock() =
+        FixedTimeEnvironment.FromClock(Clock.systemClock)
+
+    interface ISimulateEnvironment with
+        member this.NextId() = nextId ()
+        member __.Time() = now

--- a/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
+++ b/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
@@ -39,7 +39,8 @@ type FixedTimeEnvironment(now: DateTime, seed: int) =
         member __.Time() = now
 
 
-module Identifiers =
+[<RequireQualifiedAccess>]
+module PseudoRandom =
     let sequentialGuidString number = sprintf "00000000-6c78-4f2e-0000-%012i" number
     let sequentialGuid = sequentialGuidString >> Guid
     let guid (env: ISimulateEnvironment) = env.NextId() |> sequentialGuid

--- a/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
+++ b/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
@@ -43,3 +43,5 @@ module Identifiers =
     let sequentialGuidString number = sprintf "00000000-6c78-4f2e-0000-%012i" number
     let sequentialGuid = sequentialGuidString >> Guid
     let guid (env: ISimulateEnvironment) = env.NextId() |> sequentialGuid
+    let nameWithGuid prefix (env: ISimulateEnvironment) =
+        $"%s{prefix}-%O{guid env}"

--- a/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
+++ b/backend/Contexture.Api.Tests/EnvironmentSimulation.fs
@@ -3,28 +3,27 @@ namespace Contexture.Api.Tests.EnvironmentSimulation
 open System
 open System.Threading
 
-type Clock = unit -> System.DateTime
+type Clock = unit -> DateTime
 
 module Clock =
-    
-    let systemClock =
-        fun () -> System.DateTime.UtcNow
 
-    let currentInstant (clock: Clock) = clock()
+    let systemClock = fun () -> DateTime.UtcNow
+
+    let currentInstant (clock: Clock) = clock ()
+
     let dateTimeUtc (clock: Clock) =
         clock
         |> currentInstant
         |> fun t -> t.ToUniversalTime()
 
 type ISimulateEnvironment =
-    abstract Time: unit -> System.DateTime
-    abstract NextId: unit -> int
+    abstract Time : unit -> System.DateTime
+    abstract NextId : unit -> int
 
 type FixedTimeEnvironment(now: DateTime, seed: int) =
     let ids = ref seed
 
-    let nextId () =
-        Interlocked.Increment(ids)
+    let nextId () = Interlocked.Increment(ids)
 
     static member FromInstance(now: DateTime) =
         FixedTimeEnvironment(now, 0) :> ISimulateEnvironment
@@ -38,3 +37,9 @@ type FixedTimeEnvironment(now: DateTime, seed: int) =
     interface ISimulateEnvironment with
         member this.NextId() = nextId ()
         member __.Time() = now
+
+
+module Identifiers =
+    let sequentialGuidString number = sprintf "00000000-6c78-4f2e-0000-%012i" number
+    let sequentialGuid = sequentialGuidString >> Guid
+    let guid (env: ISimulateEnvironment) = env.NextId() |> sequentialGuid

--- a/backend/Contexture.Api.Tests/Fixtures.fs
+++ b/backend/Contexture.Api.Tests/Fixtures.fs
@@ -2,15 +2,13 @@ namespace Contexture.Api.Tests
 
 open System
 open Contexture.Api.Aggregates
-open Contexture.Api.Aggregates.BoundedContext
-open Contexture.Api.Aggregates.Domain
 open Contexture.Api.Aggregates.Namespace
-open Contexture.Api.Entities
-open Contexture.Api.Infrastructure
 open Contexture.Api.Tests.EnvironmentSimulation
 
 module Fixtures =
     module Domain =
+        open Domain
+
         [<Literal>]
         let Name = "domain"
 
@@ -29,8 +27,13 @@ module Fixtures =
             KeyAssigned key |> Utils.asEvent key.DomainId
 
     module BoundedContext =
+        open BoundedContext
+
         [<Literal>]
         let Name = "bounded-context"
+
+        [<Literal>]
+        let Key = "BC-1"
 
         let definition domainId contextId =
             { BoundedContextId = contextId
@@ -40,6 +43,14 @@ module Fixtures =
         let boundedContextCreated definition =
             BoundedContextCreated definition
             |> Utils.asEvent definition.BoundedContextId
+
+        let key domainId : KeyAssigned =
+            { BoundedContextId = domainId
+              Key = Some Key }
+
+        let keyAssigned key =
+            KeyAssigned key
+            |> Utils.asEvent key.BoundedContextId
 
     module Label =
 
@@ -121,11 +132,12 @@ module Fixtures =
                                  |> Domain.domainDefinition
                                  |> Domain.domainCreated
                                  domainId |> Domain.key |> Domain.keyAssigned ]
-            |> Given.andOneEvent (
+            |> Given.andEvents[
                 contextId
                 |> BoundedContext.definition domainId
                 |> BoundedContext.boundedContextCreated
-            )
+                contextId |> BoundedContext.key |> BoundedContext.keyAssigned
+            ]
 
         let givenADomainWithOneBoundedContextAndOneNamespace domainId contextId namespaceId =
             givenADomainWithOneBoundedContext domainId contextId

--- a/backend/Contexture.Api.Tests/Fixtures.fs
+++ b/backend/Contexture.Api.Tests/Fixtures.fs
@@ -1,0 +1,131 @@
+namespace Contexture.Api.Tests
+
+open System
+open Contexture.Api.Aggregates
+open Contexture.Api.Aggregates.BoundedContext
+open Contexture.Api.Aggregates.Domain
+open Contexture.Api.Aggregates.Namespace
+open Contexture.Api.Entities
+open Contexture.Api.Infrastructure
+open Contexture.Api.Tests.EnvironmentSimulation
+
+module Fixtures =
+    module Domain =
+        [<Literal>]
+        let Name = "domain"
+
+        let definition domainId : DomainCreated =
+            { DomainId = domainId; Name = "domain" }
+
+        let domainCreated definition =
+            DomainCreated definition
+            |> Utils.asEvent definition.DomainId
+
+    module BoundedContext =
+        [<Literal>]
+        let Name = "bounded-context"
+
+        let definition domainId contextId =
+            { BoundedContextId = contextId
+              Name = Name
+              DomainId = domainId }
+
+        let boundedContextCreated definition =
+            BoundedContextCreated definition
+            |> Utils.asEvent definition.BoundedContextId
+
+    module Label =
+
+        [<Literal>]
+        let Name = "architect"
+
+        [<Literal>]
+        let Value = "John Doe"
+
+        let newLabel labelId =
+            { LabelId = labelId
+              Name = Name
+              Value = Some Value
+              Template = None }
+
+    module Namespace =
+
+        [<Literal>]
+        let Name = "Team"
+
+        let definition contextId namespaceId =
+            { BoundedContextId = contextId
+              Name = Name
+              NamespaceId = namespaceId
+              NamespaceTemplateId = None
+              Labels = [] }
+
+        let appendLabel (label: LabelDefinition) (definition: NamespaceAdded) =
+            { definition with
+                  Labels = label :: definition.Labels }
+
+        let namespaceAdded definition =
+            NamespaceAdded definition
+            |> Utils.asEvent definition.BoundedContextId
+
+    
+    module Builders =
+        let givenARandomDomainWithBoundedContextAndNamespace environment =
+            let namespaceId = environment |> Identifiers.guid
+            let contextId = environment |> Identifiers.guid
+            let domainId = environment |> Identifiers.guid
+
+            Given.noEvents
+            |> Given.andOneEvent (
+                { Domain.definition domainId with
+                      Name =
+                          environment
+                          |> Identifiers.nameWithGuid "random-domain-name" }
+                |> Domain.domainCreated
+            )
+            |> Given.andOneEvent (
+                { BoundedContext.definition domainId contextId with
+                      Name =
+                          environment
+                          |> Identifiers.nameWithGuid "random-context-name" }
+                |> BoundedContext.boundedContextCreated
+            )
+            |> Given.andOneEvent (
+                { Namespace.definition contextId namespaceId with
+                      Name =
+                          environment
+                          |> Identifiers.nameWithGuid "random-namespace-name"
+                      Labels =
+                          [ { LabelId = environment |> Identifiers.guid
+                              Name =
+                                  environment
+                                  |> Identifiers.nameWithGuid "random-label-name"
+                              Value =
+                                  environment
+                                  |> Identifiers.nameWithGuid "random-label-value"
+                                  |> Some
+                              Template = None } ] }
+                |> Namespace.namespaceAdded
+            )
+
+        let givenADomainWithOneBoundedContext domainId contextId =
+            Given.noEvents
+            |> Given.andOneEvent (
+                domainId
+                |> Domain.definition
+                |> Domain.domainCreated
+            )
+            |> Given.andOneEvent (
+                contextId
+                |> BoundedContext.definition domainId
+                |> BoundedContext.boundedContextCreated
+            )
+
+        let givenADomainWithOneBoundedContextAndOneNamespace domainId contextId namespaceId =
+            givenADomainWithOneBoundedContext domainId contextId
+            |> Given.andOneEvent (
+                namespaceId
+                |> Namespace.definition contextId
+                |> Namespace.appendLabel (Label.newLabel (Guid.NewGuid()))
+                |> Namespace.namespaceAdded
+            )

--- a/backend/Contexture.Api.Tests/Fixtures.fs
+++ b/backend/Contexture.Api.Tests/Fixtures.fs
@@ -14,12 +14,19 @@ module Fixtures =
         [<Literal>]
         let Name = "domain"
 
-        let definition domainId : DomainCreated =
-            { DomainId = domainId; Name = Name }
+        [<Literal>]
+        let Key = "DO-1"
+
+        let domainDefinition domainId : DomainCreated = { DomainId = domainId; Name = Name }
 
         let domainCreated definition =
             DomainCreated definition
             |> Utils.asEvent definition.DomainId
+
+        let key domainId : KeyAssigned = { DomainId = domainId; Key = Some Key }
+
+        let keyAssigned key =
+            KeyAssigned key |> Utils.asEvent key.DomainId
 
     module BoundedContext =
         [<Literal>]
@@ -68,7 +75,7 @@ module Fixtures =
             NamespaceAdded definition
             |> Utils.asEvent definition.BoundedContextId
 
-    
+
     module Builders =
         let givenARandomDomainWithBoundedContextAndNamespace environment =
             let namespaceId = environment |> PseudoRandom.guid
@@ -77,7 +84,7 @@ module Fixtures =
 
             Given.noEvents
             |> Given.andOneEvent (
-                { Domain.definition domainId with
+                { Domain.domainDefinition domainId with
                       Name =
                           environment
                           |> PseudoRandom.nameWithGuid "random-domain-name" }
@@ -110,11 +117,10 @@ module Fixtures =
 
         let givenADomainWithOneBoundedContext domainId contextId =
             Given.noEvents
-            |> Given.andOneEvent (
-                domainId
-                |> Domain.definition
-                |> Domain.domainCreated
-            )
+            |> Given.andEvents [ domainId
+                                 |> Domain.domainDefinition
+                                 |> Domain.domainCreated
+                                 domainId |> Domain.key |> Domain.keyAssigned ]
             |> Given.andOneEvent (
                 contextId
                 |> BoundedContext.definition domainId

--- a/backend/Contexture.Api.Tests/Fixtures.fs
+++ b/backend/Contexture.Api.Tests/Fixtures.fs
@@ -15,7 +15,7 @@ module Fixtures =
         let Name = "domain"
 
         let definition domainId : DomainCreated =
-            { DomainId = domainId; Name = "domain" }
+            { DomainId = domainId; Name = Name }
 
         let domainCreated definition =
             DomainCreated definition

--- a/backend/Contexture.Api.Tests/Fixtures.fs
+++ b/backend/Contexture.Api.Tests/Fixtures.fs
@@ -71,38 +71,38 @@ module Fixtures =
     
     module Builders =
         let givenARandomDomainWithBoundedContextAndNamespace environment =
-            let namespaceId = environment |> Identifiers.guid
-            let contextId = environment |> Identifiers.guid
-            let domainId = environment |> Identifiers.guid
+            let namespaceId = environment |> PseudoRandom.guid
+            let contextId = environment |> PseudoRandom.guid
+            let domainId = environment |> PseudoRandom.guid
 
             Given.noEvents
             |> Given.andOneEvent (
                 { Domain.definition domainId with
                       Name =
                           environment
-                          |> Identifiers.nameWithGuid "random-domain-name" }
+                          |> PseudoRandom.nameWithGuid "random-domain-name" }
                 |> Domain.domainCreated
             )
             |> Given.andOneEvent (
                 { BoundedContext.definition domainId contextId with
                       Name =
                           environment
-                          |> Identifiers.nameWithGuid "random-context-name" }
+                          |> PseudoRandom.nameWithGuid "random-context-name" }
                 |> BoundedContext.boundedContextCreated
             )
             |> Given.andOneEvent (
                 { Namespace.definition contextId namespaceId with
                       Name =
                           environment
-                          |> Identifiers.nameWithGuid "random-namespace-name"
+                          |> PseudoRandom.nameWithGuid "random-namespace-name"
                       Labels =
-                          [ { LabelId = environment |> Identifiers.guid
+                          [ { LabelId = environment |> PseudoRandom.guid
                               Name =
                                   environment
-                                  |> Identifiers.nameWithGuid "random-label-name"
+                                  |> PseudoRandom.nameWithGuid "random-label-name"
                               Value =
                                   environment
-                                  |> Identifiers.nameWithGuid "random-label-value"
+                                  |> PseudoRandom.nameWithGuid "random-label-value"
                                   |> Some
                               Template = None } ] }
                 |> Namespace.namespaceAdded

--- a/backend/Contexture.Api.Tests/TestHost.fs
+++ b/backend/Contexture.Api.Tests/TestHost.fs
@@ -1,0 +1,81 @@
+namespace Contexture.Api.Tests
+
+open System
+open System.IO
+open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.Hosting
+open Microsoft.Extensions.Http
+open Microsoft.Extensions.DependencyInjection
+open Microsoft.AspNetCore.TestHost
+open Microsoft.Extensions.Logging
+open FSharp.Control.Tasks
+
+module TestHost =
+    let configureLogging (builder: ILoggingBuilder) =
+        builder.AddConsole().AddDebug() |> ignore
+
+    let createHost configureTest configureServices configure =
+        Host
+            .CreateDefaultBuilder()
+            .UseContentRoot(Directory.GetCurrentDirectory())
+            .UseEnvironment("Tests")
+            .ConfigureServices(Action<_, _> configureServices)
+            .ConfigureWebHostDefaults(fun (webHost: IWebHostBuilder) ->
+                webHost
+                    .Configure(Action<_> configure)
+                    .UseTestServer()
+                    .ConfigureTestServices(Action<_> configureTest)
+                    .ConfigureLogging(configureLogging)
+                |> ignore)
+            .ConfigureLogging(configureLogging)
+            .Build()
+
+    let runServer testConfiguration =
+        let host =
+            createHost testConfiguration Contexture.Api.App.configureServices Contexture.Api.App.configureApp
+
+        host.Start()
+        host
+
+    let staticClock time = fun () -> time
+
+    type TestEnvironment(server: IHost) =
+        let client = lazy (server.GetTestClient())
+        member __.Server = server
+        member __.Client = client.Value
+
+        member __.GetService<'Service>() =
+            server.Services.GetRequiredService<'Service>()
+
+        interface IDisposable with
+            member __.Dispose() =
+                server.Dispose()
+
+                if client.IsValueCreated then
+                    client.Value.Dispose()
+
+    let asEnvironment server = new TestEnvironment(server)
+
+
+module Prepare =
+
+    open Contexture.Api.Infrastructure
+
+    let private registerEvents givens =
+        fun (services: IServiceCollection) ->
+            services.AddSingleton<EventStore>(EventStore.With givens)
+            |> ignore
+
+    let private buildEvents clock events = events |> List.map (fun e -> e clock)
+
+    let buildServerWithEvents events =
+        events |> registerEvents |> TestHost.runServer
+
+    let withGiven clock eventBuilders =
+        let environment =
+            eventBuilders
+            |> buildEvents clock
+            |> buildServerWithEvents
+            |> TestHost.asEnvironment
+
+        environment

--- a/backend/Contexture.Api/BoundedContexts.fs
+++ b/backend/Contexture.Api/BoundedContexts.fs
@@ -123,165 +123,65 @@ module BoundedContexts =
 
                 json boundedContexts next ctx
 
-        module Search =
+        [<CLIMutable>]
+        type Query =
+            { Label: SearchFor.NamespaceId.LabelQuery option
+              Namespace: SearchFor.NamespaceId.NamespaceQuery option
+              Domain: SearchFor.DomainId.DomainQuery option }
+            member this.IsActive =
+                [ this.Label |> Option.map (fun l -> l.IsActive)
+                  this.Namespace |> Option.map (fun n -> n.IsActive)
+                  this.Domain |> Option.map (fun n -> n.IsActive) ]
+                |> List.map (Option.defaultValue false)
+                |> List.exists id
 
-            open Contexture.Api.ReadModels
+        let getBoundedContextsByQuery (item: Query) =
+            fun (next: HttpFunc) (ctx: HttpContext) ->
+                let database = ctx.GetService<EventStore>()
 
-            module NamespaceId =
+                let namespaceIds =
+                    SearchFor.NamespaceId.find database item.Namespace item.Label
 
-                [<CLIMutable>]
-                type LabelQuery =
-                    { Name: string option
-                      Value: string option }
-                    member this.IsActive = this.Name.IsSome || this.Value.IsSome
+                let domainIds =
+                    SearchFor.DomainId.findRelevantDomains database item.Domain
 
-                [<CLIMutable>]
-                type NamespaceQuery =
-                    { Template: NamespaceTemplateId option
-                      Name: string option }
-                    member this.IsActive = this.Name.IsSome || this.Template.IsSome
+                let boundedContextsByNamespace =
+                    Namespace.BoundedContexts.byNamespace database
 
-                let findRelevantNamespaces (database: EventStore) (item: NamespaceQuery) =
-                    let availableNamespaces = Find.namespaces database
+                let boundedContextsByDomain =
+                    database
+                    |> ReadModels.BoundedContext.allBoundedContextsByDomain
 
-                    let namespacesByName =
-                        item.Name
-                        |> Option.map Find.SearchPhrase.fromInput
-                        |> Option.map (Find.Namespaces.byName availableNamespaces)
-
-                    let namespacesByTemplate =
-                        item.Template
-                        |> Option.map (Find.Namespaces.byTemplate availableNamespaces)
-
-                    let relevantNamespaces =
-                        match namespacesByName, namespacesByTemplate with
-                        | Some byName, Some byTemplate -> Set.intersect byName byTemplate
-                        | Some byName, None -> byName
-                        | None, Some byTemplate -> byTemplate
-                        | None, None -> Set.empty
-
-                    relevantNamespaces
-
-                let findRelevantLabels (database: EventStore) (item: LabelQuery) =
-                    let namespacesByLabel = database |> Find.labels
-
-                    namespacesByLabel
-                    |> Find.Labels.byLabelName (
-                        item.Name
-                        |> Option.bind Find.SearchPhrase.fromInput
+                let boundedContextIdsFromNamespace =
+                    namespaceIds
+                    |> Option.map (
+                        Set.map (
+                            boundedContextsByNamespace
+                            >> Option.toList
+                            >> Set.ofList
+                        )
+                        >> Set.unionMany
                     )
-                    |> Set.filter
-                        (fun { Value = value } ->
-                            match item.Value
-                                  |> Option.bind Find.SearchPhrase.fromInput with
-                            | Some searchTerm ->
-                                value
-                                |> Option.bind Find.SearchTerm.fromInput
-                                |> Option.map (Find.SearchPhrase.matches searchTerm)
-                                |> Option.defaultValue false
-                            | None -> true)
 
-
-                let find (database: EventStore) (byNamespace: NamespaceQuery option) (byLabel: LabelQuery option) =
-                    let relevantNamespaceIds =
-                        byNamespace
-                        |> Option.map (findRelevantNamespaces database)
-                        |> Option.map (Set.map (fun n -> n.NamespaceId))
-
-                    let relevantLabels =
-                        byLabel
-                        |> Option.map (findRelevantLabels database)
-
-                    let namespacesIds =
-                        match relevantNamespaceIds, relevantLabels with
-                        | Some namespaces, Some labels ->
-                            labels
-                            |> Set.filter (fun { NamespaceId = namespaceId } -> namespaces.Contains namespaceId)
-                            |> Set.map (fun n -> n.NamespaceId)
-                            |> Some
-                        | Some namespaces, None -> Some namespaces
-                        | None, Some labels -> labels |> Set.map (fun n -> n.NamespaceId) |> Some
-                        | None, None -> None
-
-                    namespacesIds
-
-            module DomainId =
-                [<CLIMutable>]
-                type DomainQuery =
-                    { Name: string option }
-                    member this.IsActive = this.Name.IsSome
-
-                let findRelevantDomains (database: EventStore) (query: DomainQuery option) =
-                    query
-                    |> Option.map
-                        (fun item ->
-                            let findDomains = database |> Find.domains
-
-                            findDomains
-                            |> Find.Domains.byName (
-                                item.Name
-                                |> Option.bind Find.SearchPhrase.fromInput
-                            ))
-
-            [<CLIMutable>]
-            type Query =
-                { Label: NamespaceId.LabelQuery option
-                  Namespace: NamespaceId.NamespaceQuery option
-                  Domain: DomainId.DomainQuery option }
-                member this.IsActive =
-                    [ this.Label |> Option.map (fun l -> l.IsActive)
-                      this.Namespace |> Option.map (fun n -> n.IsActive)
-                      this.Domain |> Option.map (fun n -> n.IsActive) ]
-                    |> List.map (Option.defaultValue false)
-                    |> List.exists id
-
-            let getBoundedContextsByQuery (item: Query) =
-                fun (next: HttpFunc) (ctx: HttpContext) ->
-                    let database = ctx.GetService<EventStore>()
-
-                    let namespaceIds =
-                        NamespaceId.find database item.Namespace item.Label
-
-                    let domainIds =
-                        DomainId.findRelevantDomains database item.Domain
-
-                    let boundedContextsByNamespace =
-                        Namespace.BoundedContexts.byNamespace database
-
-                    let boundedContextsByDomain =
-                        database
-                        |> ReadModels.BoundedContext.allBoundedContextsByDomain
-
-                    let boundedContextIdsFromNamespace =
-                        namespaceIds
-                        |> Option.map (
-                            Set.map (
-                                boundedContextsByNamespace
-                                >> Option.toList
-                                >> Set.ofList
-                            )
-                            >> Set.unionMany
+                let boundedContextIdsFromDomain =
+                    domainIds
+                    |> Option.map (
+                        Set.map (
+                            boundedContextsByDomain
+                            >> List.map (fun b -> b.Id)
+                            >> Set.ofList
                         )
+                        >> Set.unionMany
+                    )
 
-                    let boundedContextIdsFromDomain =
-                        domainIds
-                        |> Option.map (
-                            Set.map (
-                                boundedContextsByDomain
-                                >> List.map (fun b -> b.Id)
-                                >> Set.ofList
-                            )
-                            >> Set.unionMany
-                        )
+                let boundedContextIds =
+                    match boundedContextIdsFromNamespace, boundedContextIdsFromDomain with
+                    | Some fromNamespace, Some fromDomain -> Set.intersect fromNamespace fromDomain
+                    | Some fromNamespace, None -> fromNamespace
+                    | None, Some fromDomain -> fromDomain
+                    | None, None -> Set.empty
 
-                    let boundedContextIds =
-                        match boundedContextIdsFromNamespace, boundedContextIdsFromDomain with
-                        | Some fromNamespace, Some fromDomain -> Set.intersect fromNamespace fromDomain
-                        | Some fromNamespace, None -> fromNamespace
-                        | None, Some fromDomain -> fromDomain
-                        | None, None -> Set.empty
-
-                    mapToBoundedContext database (Set.toList boundedContextIds) next ctx
+                mapToBoundedContext database (Set.toList boundedContextIds) next ctx
 
         let getBoundedContexts =
             fun (next: HttpFunc) (ctx: HttpContext) ->
@@ -299,8 +199,8 @@ module BoundedContexts =
             fun (next: HttpFunc) (ctx: HttpContext) ->
                 let nextHandler =
                     if ctx.Request.QueryString.HasValue then
-                        match ctx.TryBindQueryString<Search.Query>() with
-                        | Ok query when query.IsActive -> Search.getBoundedContextsByQuery query
+                        match ctx.TryBindQueryString<Query>() with
+                        | Ok query when query.IsActive -> getBoundedContextsByQuery query
                         | _ -> getBoundedContexts
                     else
                         getBoundedContexts

--- a/backend/Contexture.Api/BoundedContexts.fs
+++ b/backend/Contexture.Api/BoundedContexts.fs
@@ -126,9 +126,9 @@ module BoundedContexts =
                 json boundedContexts next ctx
 
         module Search =
-            
-            
-            
+
+
+
             [<CLIMutable>]
             type LabelQuery =
                 { Name: string option
@@ -160,6 +160,7 @@ module BoundedContexts =
 
                 let namespacesByName =
                     item.Name
+                    |> Option.map SearchPhrase.fromInput
                     |> Option.map (ReadModels.Namespace.Find.Namespaces.byName availableNamespaces)
 
                 let namespacesByTemplate =
@@ -177,8 +178,7 @@ module BoundedContexts =
 
             let findRelevantLabels (database: EventStore) (item: LabelQuery) =
                 let namespacesByLabel =
-                    database
-                    |> ReadModels.Namespace.Find.labels
+                    database |> ReadModels.Namespace.Find.labels
 
                 namespacesByLabel
                 |> ReadModels.Namespace.Find.Labels.byLabelName (item.Name |> Option.bind SearchPhrase.fromInput)

--- a/backend/Contexture.Api/Contexture.Api.fsproj
+++ b/backend/Contexture.Api/Contexture.Api.fsproj
@@ -23,6 +23,7 @@
     <Compile Include="Views.fs" />
     <Compile Include="Domains.fs" />
     <Compile Include="Namespaces.fs" />
+    <Compile Include="SearchHandler.fs" />
     <Compile Include="BoundedContexts.fs" />
     <Compile Include="Collaborations.fs" />
     <Compile Include="Search.fs" />

--- a/backend/Contexture.Api/Contexture.Api.fsproj
+++ b/backend/Contexture.Api/Contexture.Api.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="Infrastructure.fs" />
     <Compile Include="CommandHandlers.fs" />
     <Compile Include="ReadModels\ReadModels.fs" />
+    <Compile Include="ReadModels\Find.fs" />
     <Compile Include="Views.fs" />
     <Compile Include="Domains.fs" />
     <Compile Include="Namespaces.fs" />

--- a/backend/Contexture.Api/Contexture.Api.fsproj
+++ b/backend/Contexture.Api/Contexture.Api.fsproj
@@ -18,7 +18,7 @@
     <Compile Include="Database.fs" />
     <Compile Include="Infrastructure.fs" />
     <Compile Include="CommandHandlers.fs" />
-    <Compile Include="ReadModels.fs" />
+    <Compile Include="ReadModels\ReadModels.fs" />
     <Compile Include="Views.fs" />
     <Compile Include="Domains.fs" />
     <Compile Include="Namespaces.fs" />

--- a/backend/Contexture.Api/Program.fs
+++ b/backend/Contexture.Api/Program.fs
@@ -30,7 +30,8 @@ let allRoute =
             let result =
                 {| BoundedContexts = document.BoundedContexts.All
                    Domains = document.Domains.All
-                   Collaborations = document.Collaborations.All |}
+                   Collaborations = document.Collaborations.All
+                   NamespaceTemplates = document.NamespaceTemplates.All |}
             json result next ctx
 
 let webApp hostFrontend =

--- a/backend/Contexture.Api/ReadModels.fs
+++ b/backend/Contexture.Api/ReadModels.fs
@@ -290,15 +290,6 @@ module Namespace =
                     state
                     |> removeFromSet (fun n -> n.NamespaceId) n.NamespaceId
 
-            let getByLabelName (labelName: string) (namespaces: NamespacesByLabel) =
-                let searchedKey = labelName.ToLowerInvariant()
-
-                namespaces
-                |> Map.filter (fun k _ -> k = searchedKey)
-                |> Map.toList
-                |> List.map snd
-                |> Set.unionMany
-
             let byLabelName (phrase: SearchPhrase option) (namespaces: NamespacesByLabel) =
                 let matchesKey (key: string) =
                     let term = SearchTerm.fromInput key |> Option.get

--- a/backend/Contexture.Api/ReadModels/Find.fs
+++ b/backend/Contexture.Api/ReadModels/Find.fs
@@ -1,0 +1,230 @@
+namespace Contexture.Api.ReadModels
+
+open System
+open Contexture.Api
+open Contexture.Api.Aggregates.Namespace
+open Contexture.Api.Infrastructure
+open Entities
+
+module Find =
+    type Operator =
+        | Equals
+        | StartsWith
+        | Contains
+        | EndsWith
+
+    type SearchPhrase = private | SearchPhrase of Operator * string
+
+    type SearchTerm = private SearchTerm of string
+
+    module SearchTerm =
+        let fromInput (term: string) =
+            term
+            |> Option.ofObj
+            |> Option.filter (not << String.IsNullOrWhiteSpace)
+            |> Option.map (fun s -> s.Trim())
+            |> Option.map SearchTerm
+
+        let value (SearchTerm term) = term
+
+    module SearchPhrase =
+
+        let private operatorAndPhrase (phrase: string) =
+            match phrase.StartsWith "*", phrase.EndsWith "*" with
+            | true, true -> // *phrase*
+                Contains, phrase.Trim '*'
+            | true, false -> // *phrase
+                EndsWith, phrase.TrimStart '*'
+            | false, true -> // phrase*
+                StartsWith, phrase.TrimEnd '*'
+            | false, false -> // phrase
+                Equals, phrase
+
+        let fromInput (phrase: string) =
+            phrase
+            |> Option.ofObj
+            |> Option.filter (not << String.IsNullOrWhiteSpace)
+            |> Option.map (fun s -> s.Trim())
+            |> Option.map operatorAndPhrase
+            |> Option.map SearchPhrase
+
+        let matches (SearchPhrase (operator, phrase)) (SearchTerm value) =
+            match operator with
+            | Equals -> String.Equals(phrase, value, StringComparison.OrdinalIgnoreCase)
+            | StartsWith -> value.StartsWith(phrase, StringComparison.OrdinalIgnoreCase)
+            | EndsWith -> value.EndsWith(phrase, StringComparison.OrdinalIgnoreCase)
+            | Contains -> value.Contains(phrase, StringComparison.OrdinalIgnoreCase)
+
+    let private appendToSet items (key: string, value) =
+        items
+        |> Map.change
+            key
+            (function
+            | Some values -> values |> Set.add value |> Some
+            | None -> value |> Set.singleton |> Some)
+
+    let private removeFromSet findValue value items =
+        items
+        |> Map.map
+            (fun _ (values: Set<_>) ->
+                values
+                |> Set.filter (fun n -> findValue n <> value))
+
+    let private findByKey keyPhrase items =
+        let matchesKey (key: string) =
+            let term = SearchTerm.fromInput key |> Option.get
+
+            match keyPhrase with
+            | Some searchTerm -> SearchPhrase.matches searchTerm term
+            | None -> true
+
+        items
+        |> Map.filter (fun k _ -> matchesKey k)
+        |> Map.toList
+        |> List.map snd
+        |> Set.unionMany
+
+    module Namespaces =
+        type NamespaceModel =
+            { NamespaceId: NamespaceId
+              NamespaceTemplateId: NamespaceTemplateId option }
+
+        type NamespaceFinder = Map<string, Set<NamespaceModel>>
+
+        let projectNamespaceNameToNamespaceId state eventEnvelope =
+            match eventEnvelope.Event with
+            | NamespaceAdded n ->
+                appendToSet
+                    state
+                    (n.Name,
+                     { NamespaceId = n.NamespaceId
+                       NamespaceTemplateId = n.NamespaceTemplateId })
+            | NamespaceImported n ->
+                appendToSet
+                    state
+                    (n.Name,
+                     { NamespaceId = n.NamespaceId
+                       NamespaceTemplateId = n.NamespaceTemplateId })
+            | NamespaceRemoved n ->
+                state
+                |> removeFromSet (fun i -> i.NamespaceId) n.NamespaceId
+            | LabelAdded l -> state
+            | LabelRemoved l -> state
+
+        let byName (namespaces: NamespaceFinder) (name: SearchPhrase option) = namespaces |> findByKey name
+
+        let byTemplate (namespaces: NamespaceFinder) (templateId: NamespaceTemplateId) =
+            namespaces
+            |> Map.toList
+            |> List.map snd
+            |> Set.unionMany
+            |> Set.filter (fun m -> m.NamespaceTemplateId = Some templateId)
+
+    let namespaces (eventStore: EventStore) : Namespaces.NamespaceFinder =
+        eventStore.Get<Aggregates.Namespace.Event>()
+        |> List.fold Namespaces.projectNamespaceNameToNamespaceId Map.empty
+
+    module Labels =
+        type LabelAndNamespaceModel =
+            { Value: string option
+              NamespaceId: NamespaceId
+              NamespaceTemplateId: NamespaceTemplateId option }
+
+        type NamespacesByLabel = Map<string, Set<LabelAndNamespaceModel>>
+
+        let projectLabelNameToNamespace state eventEnvelope =
+            match eventEnvelope.Event with
+            | NamespaceAdded n ->
+                n.Labels
+                |> List.map
+                    (fun l ->
+                        l.Name,
+                        { Value = l.Value
+                          NamespaceId = n.NamespaceId
+                          NamespaceTemplateId = n.NamespaceTemplateId })
+                |> List.fold appendToSet state
+            | NamespaceImported n ->
+                n.Labels
+                |> List.map
+                    (fun l ->
+                        l.Name,
+                        { Value = l.Value
+                          NamespaceId = n.NamespaceId
+                          NamespaceTemplateId = n.NamespaceTemplateId })
+                |> List.fold appendToSet state
+            | LabelAdded l ->
+                appendToSet
+                    state
+                    (l.Name,
+                     { Value = l.Value
+                       NamespaceId = l.NamespaceId
+                       NamespaceTemplateId = None })
+            | LabelRemoved l ->
+                state
+                |> removeFromSet (fun n -> n.NamespaceId) l.NamespaceId
+            | NamespaceRemoved n ->
+                state
+                |> removeFromSet (fun n -> n.NamespaceId) n.NamespaceId
+
+        let byLabelName (phrase: SearchPhrase option) (namespaces: NamespacesByLabel) = namespaces |> findByKey phrase
+
+    let labels (eventStore: EventStore) : Labels.NamespacesByLabel =
+        eventStore.Get<Aggregates.Namespace.Event>()
+        |> List.fold Labels.projectLabelNameToNamespace Map.empty
+
+    module Domains =
+        open Contexture.Api.Aggregates.Domain
+
+        type DomainByKeyAndNameModel =
+            { ByKey: Map<string, DomainId>
+              ByName: Map<string, Set<DomainId>> }
+            static member Empty =
+                { ByKey = Map.empty
+                  ByName = Map.empty }
+
+        let projectToDomain state eventEnvelope =
+            let addKey canBeKey domain byKey =
+                match canBeKey with
+                | Some key -> byKey |> Map.add key domain
+                | None -> byKey
+
+            let append key value items = appendToSet items (key, value)
+
+            match eventEnvelope.Event with
+            | SubDomainCreated n ->
+                { state with
+                      ByName = state.ByName |> append n.Name n.DomainId }
+            | DomainCreated n ->
+                { state with
+                      ByName = state.ByName |> append n.Name n.DomainId }
+            | KeyAssigned k ->
+                { state with
+                      ByKey =
+                          state.ByKey
+                          |> Map.filter (fun _ v -> v <> k.DomainId)
+                          |> addKey k.Key k.DomainId }
+            | DomainImported n ->
+                { state with
+                      ByName = appendToSet state.ByName (n.Name, n.DomainId)
+                      ByKey = state.ByKey |> addKey n.Key n.DomainId }
+            | DomainRenamed l ->
+                { state with
+                      ByName =
+                          state.ByName
+                          |> removeFromSet id l.DomainId
+                          |> append l.Name l.DomainId }
+            | DomainRemoved l ->
+                { state with
+                      ByName = state.ByName |> removeFromSet id l.DomainId
+                      ByKey =
+                          state.ByKey
+                          |> Map.filter (fun _ v -> v <> l.DomainId) }
+            | CategorizedAsSubdomain _
+            | PromotedToDomain _
+            | VisionRefined _ -> state
+
+        let byName (phrase: SearchPhrase option) (model: DomainByKeyAndNameModel) = model.ByName |> findByKey phrase
+
+    let domains (eventStore: EventStore) : Domains.DomainByKeyAndNameModel =
+        eventStore.Get<Aggregates.Domain.Event>()
+        |> List.fold Domains.projectToDomain Domains.DomainByKeyAndNameModel.Empty

--- a/backend/Contexture.Api/ReadModels/Find.fs
+++ b/backend/Contexture.Api/ReadModels/Find.fs
@@ -82,6 +82,10 @@ module Find =
         |> Map.filter (fun k _ -> matchesKey k)
         |> Map.toList
         |> List.map snd
+        
+    let private findByKeySet keyPhrase items =
+        items
+        |> findByKey keyPhrase
         |> Set.unionMany
 
     module Namespaces =
@@ -111,7 +115,7 @@ module Find =
             | LabelAdded l -> state
             | LabelRemoved l -> state
 
-        let byName (namespaces: NamespaceFinder) (name: SearchPhrase option) = namespaces |> findByKey name
+        let byName (namespaces: NamespaceFinder) (name: SearchPhrase option) = namespaces |> findByKeySet name
 
         let byTemplate (namespaces: NamespaceFinder) (templateId: NamespaceTemplateId) =
             namespaces
@@ -166,7 +170,7 @@ module Find =
                 state
                 |> removeFromSet (fun n -> n.NamespaceId) n.NamespaceId
 
-        let byLabelName (phrase: SearchPhrase option) (namespaces: NamespacesByLabel) = namespaces |> findByKey phrase
+        let byLabelName (phrase: SearchPhrase option) (namespaces: NamespacesByLabel) = namespaces |> findByKeySet phrase
 
     let labels (eventStore: EventStore) : Labels.NamespacesByLabel =
         eventStore.Get<Aggregates.Namespace.Event>()
@@ -223,7 +227,8 @@ module Find =
             | PromotedToDomain _
             | VisionRefined _ -> state
 
-        let byName (phrase: SearchPhrase option) (model: DomainByKeyAndNameModel) = model.ByName |> findByKey phrase
+        let byName (model: DomainByKeyAndNameModel) (phrase: SearchPhrase option) = model.ByName |> findByKeySet phrase
+        let byKey (model: DomainByKeyAndNameModel) (phrase: SearchPhrase option) = model.ByKey |> findByKey phrase |> Set.ofList
 
     let domains (eventStore: EventStore) : Domains.DomainByKeyAndNameModel =
         eventStore.Get<Aggregates.Domain.Event>()

--- a/backend/Contexture.Api/ReadModels/ReadModels.fs
+++ b/backend/Contexture.Api/ReadModels/ReadModels.fs
@@ -146,8 +146,7 @@ module Namespace =
             | EndsWith
         
         type SearchPhrase =
-            private SearchPhrase of Operator * string
-            
+            private SearchPhrase of Operator * string  
             
         type SearchTerm =
             private SearchTerm of string

--- a/backend/Contexture.Api/ReadModels/ReadModels.fs
+++ b/backend/Contexture.Api/ReadModels/ReadModels.fs
@@ -1,7 +1,5 @@
 namespace Contexture.Api.ReadModels
 
-
-open System
 open Contexture.Api
 open Contexture.Api.Aggregates.NamespaceTemplate.Projections
 open Contexture.Api.Infrastructure
@@ -135,257 +133,22 @@ module Namespace =
         boundedContextId
         |> eventStore.Stream
         |> project namespacesProjection
+    
+    module BoundedContexts =
+        let private projectNamespaceIdToBoundedContextId state eventEnvelope =
+            match eventEnvelope.Event with
+            | NamespaceAdded n -> state |> Map.add n.NamespaceId n.BoundedContextId
+            | NamespaceImported n -> state |> Map.add n.NamespaceId n.BoundedContextId
+            | NamespaceRemoved n -> state |> Map.remove n.NamespaceId
+            | LabelAdded l -> state
+            | LabelRemoved l -> state
 
+        let byNamespace (eventStore: EventStore) =
+            let namespaces =
+                eventStore.Get<Aggregates.Namespace.Event>()
+                |> List.fold projectNamespaceIdToBoundedContextId Map.empty
 
-
-    module Find =
-        type Operator =
-            | Equals
-            | StartsWith
-            | Contains
-            | EndsWith
-        
-        type SearchPhrase =
-            private SearchPhrase of Operator * string  
-            
-        type SearchTerm =
-            private SearchTerm of string
-            
-        module SearchTerm =
-            let fromInput (term: string) =
-                term
-                |> Option.ofObj
-                |> Option.filter(not<<String.IsNullOrWhiteSpace)
-                |> Option.map (fun s -> s.Trim())
-                |> Option.map SearchTerm
-                
-            let value (SearchTerm term) = term
-            
-        module SearchPhrase =
-            
-            let private operatorAndPhrase (phrase: string) =
-                match phrase.StartsWith "*", phrase.EndsWith "*" with
-                | true, true -> // *phrase*
-                    Contains, phrase.Trim '*'
-                | true, false -> // *phrase
-                    EndsWith, phrase.TrimStart '*'
-                | false, true -> // phrase*
-                    StartsWith, phrase.TrimEnd '*'
-                | false, false -> // phrase
-                    Equals, phrase
-            
-            let fromInput (phrase: string) =
-                phrase
-                |> Option.ofObj
-                |> Option.filter(not<<String.IsNullOrWhiteSpace)
-                |> Option.map (fun s -> s.Trim())
-                |> Option.map operatorAndPhrase
-                |> Option.map SearchPhrase
-                
-            let matches (SearchPhrase (operator, phrase)) (SearchTerm value) =
-                match operator with
-                | Equals -> String.Equals (phrase, value, StringComparison.OrdinalIgnoreCase)
-                | StartsWith -> value.StartsWith (phrase, StringComparison.OrdinalIgnoreCase)
-                | EndsWith -> value.EndsWith (phrase, StringComparison.OrdinalIgnoreCase)
-                | Contains -> value.Contains (phrase, StringComparison.OrdinalIgnoreCase)
-                
-        let private appendToSet items (key: string, value) =
-            items
-            |> Map.change
-                key
-                (function
-                | Some values -> values |> Set.add value |> Some
-                | None -> value |> Set.singleton |> Some)
-
-        let private removeFromSet findValue value items =
-            items
-            |> Map.map
-                (fun _ (values: Set<_>) ->
-                    values
-                    |> Set.filter (fun n -> findValue n <> value))
-                
-        let private findByKey keyPhrase items =
-            let matchesKey (key: string) =
-                let term = SearchTerm.fromInput key |> Option.get
-                match keyPhrase with
-                | Some searchTerm -> SearchPhrase.matches searchTerm term
-                | None -> true
-
-            items
-            |> Map.filter (fun k _ -> matchesKey k)
-            |> Map.toList
-            |> List.map snd
-            |> Set.unionMany
-
-        module Namespaces =
-            type NamespaceModel =
-                { NamespaceId: NamespaceId
-                  NamespaceTemplateId: NamespaceTemplateId option }
-
-            type NamespaceFinder = Map<string, Set<NamespaceModel>>
-
-            let projectNamespaceNameToNamespaceId state eventEnvelope =
-                match eventEnvelope.Event with
-                | NamespaceAdded n ->
-                    appendToSet
-                        state
-                        (n.Name,
-                         { NamespaceId = n.NamespaceId
-                           NamespaceTemplateId = n.NamespaceTemplateId })
-                | NamespaceImported n ->
-                    appendToSet
-                        state
-                        (n.Name,
-                         { NamespaceId = n.NamespaceId
-                           NamespaceTemplateId = n.NamespaceTemplateId })
-                | NamespaceRemoved n ->
-                    state
-                    |> removeFromSet (fun i -> i.NamespaceId) n.NamespaceId
-                | LabelAdded l -> state
-                | LabelRemoved l -> state
-
-            let byName (namespaces: NamespaceFinder) (name: SearchPhrase option) =
-                namespaces
-                |> findByKey name
-
-            let byTemplate (namespaces: NamespaceFinder) (templateId: NamespaceTemplateId) =
-                namespaces
-                |> Map.toList
-                |> List.map snd
-                |> Set.unionMany
-                |> Set.filter (fun m -> m.NamespaceTemplateId = Some templateId)
-
-        let namespaces (eventStore: EventStore) : Namespaces.NamespaceFinder =
-            eventStore.Get<Aggregates.Namespace.Event>()
-            |> List.fold Namespaces.projectNamespaceNameToNamespaceId Map.empty
-
-        module Labels =
-            type LabelAndNamespaceModel =
-                { Value: string option
-                  NamespaceId: NamespaceId
-                  NamespaceTemplateId: NamespaceTemplateId option }
-
-            type NamespacesByLabel = Map<string, Set<LabelAndNamespaceModel>>
-
-            let projectLabelNameToNamespace state eventEnvelope =
-                match eventEnvelope.Event with
-                | NamespaceAdded n ->
-                    n.Labels
-                    |> List.map
-                        (fun l ->
-                            l.Name,
-                            { Value = l.Value
-                              NamespaceId = n.NamespaceId
-                              NamespaceTemplateId = n.NamespaceTemplateId })
-                    |> List.fold appendToSet state
-                | NamespaceImported n ->
-                    n.Labels
-                    |> List.map
-                        (fun l ->
-                            l.Name,
-                            { Value = l.Value
-                              NamespaceId = n.NamespaceId
-                              NamespaceTemplateId = n.NamespaceTemplateId })
-                    |> List.fold appendToSet state
-                | LabelAdded l ->
-                    appendToSet
-                        state
-                        (l.Name,
-                         { Value = l.Value
-                           NamespaceId = l.NamespaceId
-                           NamespaceTemplateId = None })
-                | LabelRemoved l ->
-                    state
-                    |> removeFromSet (fun n -> n.NamespaceId) l.NamespaceId
-                | NamespaceRemoved n ->
-                    state
-                    |> removeFromSet (fun n -> n.NamespaceId) n.NamespaceId
-
-            let byLabelName (phrase: SearchPhrase option) (namespaces: NamespacesByLabel) =
-                namespaces
-                |> findByKey phrase
-
-        let labels (eventStore: EventStore) : Labels.NamespacesByLabel =
-            eventStore.Get<Aggregates.Namespace.Event>()
-            |> List.fold Labels.projectLabelNameToNamespace Map.empty
-
-        module Domains =
-            open Contexture.Api.Aggregates.Domain
-            type DomainByKeyAndNameModel =
-                { ByKey : Map<string,DomainId>
-                  ByName: Map<string,Set<DomainId>> }
-                with static member Empty = { ByKey = Map.empty; ByName = Map.empty }
-
-            let projectToDomain state eventEnvelope =
-                let addKey canBeKey domain byKey =
-                    match canBeKey with
-                    | Some key -> byKey |> Map.add key domain
-                    | None -> byKey
-                let append key value items =
-                    appendToSet items (key, value)
-                match eventEnvelope.Event with
-                | SubDomainCreated n ->
-                    { state with
-                        ByName = state.ByName |> append n.Name n.DomainId }
-                | DomainCreated n ->
-                    { state with
-                        ByName = state.ByName |> append n.Name n.DomainId }
-                | KeyAssigned k ->
-                    { state with
-                        ByKey =
-                            state.ByKey
-                            |> Map.filter(fun _ v -> v <> k.DomainId)
-                            |> addKey k.Key k.DomainId
-                    }
-                | DomainImported n ->
-                    { state with
-                        ByName = appendToSet state.ByName (n.Name, n.DomainId)
-                        ByKey = state.ByKey |> addKey n.Key n.DomainId
-                        }
-                | DomainRenamed l ->
-                    { state with
-                        ByName =
-                            state.ByName
-                            |> removeFromSet id l.DomainId
-                            |> append l.Name l.DomainId
-                         }
-                | DomainRemoved l ->
-                    { state with
-                        ByName =
-                            state.ByName
-                            |> removeFromSet id l.DomainId
-                        ByKey =
-                            state.ByKey
-                            |> Map.filter (fun _ v -> v <> l.DomainId)
-                    }
-                | CategorizedAsSubdomain _
-                | PromotedToDomain _
-                | VisionRefined _ ->
-                    state
-
-            let byName (phrase: SearchPhrase option) (model: DomainByKeyAndNameModel) =
-                model.ByName
-                |> findByKey phrase
-                
-        let domains (eventStore: EventStore) : Domains.DomainByKeyAndNameModel =
-            eventStore.Get<Aggregates.Domain.Event>()
-            |> List.fold Domains.projectToDomain Domains.DomainByKeyAndNameModel.Empty
-        
-        module BoundedContexts =
-            let private projectNamespaceIdToBoundedContextId state eventEnvelope =
-                match eventEnvelope.Event with
-                | NamespaceAdded n -> state |> Map.add n.NamespaceId n.BoundedContextId
-                | NamespaceImported n -> state |> Map.add n.NamespaceId n.BoundedContextId
-                | NamespaceRemoved n -> state |> Map.remove n.NamespaceId
-                | LabelAdded l -> state
-                | LabelRemoved l -> state
-
-            let byNamespace (eventStore: EventStore) =
-                let namespaces =
-                    eventStore.Get<Aggregates.Namespace.Event>()
-                    |> List.fold projectNamespaceIdToBoundedContextId Map.empty
-
-                fun (namespaceId: NamespaceId) -> namespaces |> Map.tryFind namespaceId
+            fun (namespaceId: NamespaceId) -> namespaces |> Map.tryFind namespaceId
 
 module Templates =
     open Contexture.Api.Aggregates.NamespaceTemplate

--- a/backend/Contexture.Api/Search.fs
+++ b/backend/Contexture.Api/Search.fs
@@ -46,12 +46,6 @@ module Search =
 
             let domains = Domain.allDomains eventStore
 
-            let boundedContextsOf =
-                BoundedContext.allBoundedContextsByDomain eventStore
-
-            let namespacesOf =
-                Namespace.allNamespacesByContext eventStore
-
             let collaborations =
                 Collaboration.allCollaborations eventStore
 

--- a/backend/Contexture.Api/SearchHandler.fs
+++ b/backend/Contexture.Api/SearchHandler.fs
@@ -1,0 +1,105 @@
+namespace Contexture.Api
+
+open System
+open Contexture.Api.Entities
+open Contexture.Api.Aggregates.BoundedContext
+open Contexture.Api.Infrastructure
+open Contexture.Api.ReadModels
+
+module SearchFor =
+
+    module NamespaceId =
+
+        [<CLIMutable>]
+        type LabelQuery =
+            { Name: string option
+              Value: string option }
+            member this.IsActive = this.Name.IsSome || this.Value.IsSome
+
+        [<CLIMutable>]
+        type NamespaceQuery =
+            { Template: NamespaceTemplateId option
+              Name: string option }
+            member this.IsActive = this.Name.IsSome || this.Template.IsSome
+
+        let findRelevantNamespaces (database: EventStore) (item: NamespaceQuery) =
+            let availableNamespaces = Find.namespaces database
+
+            let namespacesByName =
+                item.Name
+                |> Option.map Find.SearchPhrase.fromInput
+                |> Option.map (Find.Namespaces.byName availableNamespaces)
+
+            let namespacesByTemplate =
+                item.Template
+                |> Option.map (Find.Namespaces.byTemplate availableNamespaces)
+
+            let relevantNamespaces =
+                match namespacesByName, namespacesByTemplate with
+                | Some byName, Some byTemplate -> Set.intersect byName byTemplate
+                | Some byName, None -> byName
+                | None, Some byTemplate -> byTemplate
+                | None, None -> Set.empty
+
+            relevantNamespaces
+
+        let findRelevantLabels (database: EventStore) (item: LabelQuery) =
+            let namespacesByLabel = database |> Find.labels
+
+            namespacesByLabel
+            |> Find.Labels.byLabelName (
+                item.Name
+                |> Option.bind Find.SearchPhrase.fromInput
+            )
+            |> Set.filter
+                (fun { Value = value } ->
+                    match item.Value
+                          |> Option.bind Find.SearchPhrase.fromInput with
+                    | Some searchTerm ->
+                        value
+                        |> Option.bind Find.SearchTerm.fromInput
+                        |> Option.map (Find.SearchPhrase.matches searchTerm)
+                        |> Option.defaultValue false
+                    | None -> true)
+
+
+        let find (database: EventStore) (byNamespace: NamespaceQuery option) (byLabel: LabelQuery option) =
+            let relevantNamespaceIds =
+                byNamespace
+                |> Option.map (findRelevantNamespaces database)
+                |> Option.map (Set.map (fun n -> n.NamespaceId))
+
+            let relevantLabels =
+                byLabel
+                |> Option.map (findRelevantLabels database)
+
+            let namespacesIds =
+                match relevantNamespaceIds, relevantLabels with
+                | Some namespaces, Some labels ->
+                    labels
+                    |> Set.filter (fun { NamespaceId = namespaceId } -> namespaces.Contains namespaceId)
+                    |> Set.map (fun n -> n.NamespaceId)
+                    |> Some
+                | Some namespaces, None -> Some namespaces
+                | None, Some labels -> labels |> Set.map (fun n -> n.NamespaceId) |> Some
+                | None, None -> None
+
+            namespacesIds
+
+    module DomainId =
+        [<CLIMutable>]
+        type DomainQuery =
+            { Name: string option }
+            member this.IsActive = this.Name.IsSome
+
+        let findRelevantDomains (database: EventStore) (query: DomainQuery option) =
+            query
+            |> Option.map
+                (fun item ->
+                    let findDomains = database |> Find.domains
+
+                    findDomains
+                    |> Find.Domains.byName (
+                        item.Name
+                        |> Option.bind Find.SearchPhrase.fromInput
+                    ))


### PR DESCRIPTION
Supporting `*` as operator for (string based) fields:
- attaching it at the beginning of a parameter gives you 'ends with semantics', e.g. `*value` will match all fields ending with 'value'
- attaching it at the end of a parameter gives you 'starts with semantics', e.g. `value*` will match all fields starting with 'value'
- specifying it on start and end gives you 'contains semantics', e.g. `*value*` will match all fields containing 'value'
- no operator will fall back to 'equal semantics', e.g. `value` will match all fields equal to 'value'

Note: all queries are evaluated in a case insensitive way.

In addition search via 
- `Domain.name` and `Domain.key`
- `BoundedContext.name` and `BoundedContext.key` is now possible