### PR TITLE
Fix: when switching between visualisation modes

### DIFF
--- a/frontend/src/Page/Searching/Searching.elm
+++ b/frontend/src/Page/Searching/Searching.elm
@@ -254,6 +254,7 @@ viewItems searchResults =
 viewSunburst configuration filterParameters mode =
     Html.node "visualization-sunburst"
         [ attribute "baseApi" (Api.withoutQuery [] |> Api.url configuration)
+        , attribute "query" (filterParameters |> filterParametersAsQuery |> Url.Builder.toQuery)
         , attribute "mode"
             (case mode of
                 Filtered ->
@@ -262,7 +263,6 @@ viewSunburst configuration filterParameters mode =
                 Highlighted ->
                     "highlighted"
             )
-        , attribute "query" (filterParameters |> filterParametersAsQuery |> Url.Builder.toQuery)
         ]
         []
 


### PR DESCRIPTION
A sunburst visualisation has 2 attributes. When attribute changes we call new request. We have 2 attributes, so we call twice requests.

Early a mode attribute has been called before then a query attribute.
So first data query was with empty query value and second request with filled query.
And if the first request finished after second request, then our visualisation was like the query was empty
